### PR TITLE
docs: update deployment lesson with prereqs, formatting, and new directives

### DIFF
--- a/content/curriculum/00-orientation/deployment.md
+++ b/content/curriculum/00-orientation/deployment.md
@@ -16,9 +16,16 @@ knowledgeCheck:
   - question: When a deploy fails, the lesson says to read the build log from the bottom up. Why the bottom, and what kind of information does a build log give you that you would not get from just looking at your code?
 ---
 
+:::prereq
+You will need two things set up before starting this lesson:
+
+- **GitHub credentials configured locally.** You need to be able to push code from your terminal to GitHub. If you have not done this yet, follow GitHub's guide to [setting up authentication](https://docs.github.com/en/get-started/getting-started-with-git/set-up-git#authenticating-with-github-from-git). The easiest option is HTTPS with a personal access token or the GitHub CLI (`gh auth login`).
+- **A Netlify account.** Sign up at [netlify.com](https://www.netlify.com) using your GitHub account. The free tier is all you need.
+:::
+
 ## What Does "Deployed" Mean?
 
-Your project works on your computer at localhost:3000. You can see it, click around, and it feels real. But nobody else can see it. Your computer is not a web server; it is not listening for requests from the outside world.
+Your project works on your computer at `localhost:3000`. You can see it, click around, and it feels real. But nobody else can see it. Your computer is not a web server; it is not listening for requests from the outside world.
 
 Deployment means putting your project on a server that is connected to the internet, so anyone with the URL can access it. That is the gap between "it works on my machine" and "it is live." Closing that gap is one of the most satisfying moments in building.
 
@@ -38,9 +45,9 @@ Most things you build early will be static, and that is fine. Static sites are f
 
 When you write code in React, Vue, or any modern framework, your browser cannot read it directly. JSX is not HTML. Sass is not CSS. Your source code needs to be compiled into plain HTML, CSS, and JavaScript that browsers understand.
 
-This is the build step. You run a command, usually npm run build, and your build tool (Vite, Webpack, etc.) processes everything, optimizes it, and outputs the result into a dist/ or build/ folder.
+This is the build step. You run a command, usually `npm run build`, and your build tool (Vite, Webpack, etc.) processes everything, optimizes it, and outputs the result into a `dist/` or `build/` folder.
 
-The dist/ folder is what gets deployed. Not your source code, not your node_modules, not your .env file. Just the clean, compiled output. This is why deployment and development are separate steps: what you work with is not what you ship.
+The `dist/` folder is what gets deployed. Not your source code, not your `node_modules`, not your `.env` file. Just the clean, compiled output. This is why deployment and development are separate steps: what you work with is not what you ship.
 
 ```
 # Build your project for production
@@ -59,58 +66,60 @@ npm run build
 
 The easiest way to deploy a static site is through a platform that connects to your GitHub repo, watches for pushes, and auto-deploys your latest code. The three most popular:
 
-Netlify offers a generous free tier, excellent for static sites and simple serverless functions. Zero Vector is deployed on Netlify. Drag-and-drop deploy is available, but Git-based deploy is better.
+**Netlify** offers a generous free tier, excellent for static sites and simple serverless functions. Zero Vector is deployed on Netlify. Drag-and-drop deploy is available, but Git-based deploy is better.
 
-Vercel was built by the creators of Next.js. Great developer experience, fast CDN, similar free tier. Particularly good for Next.js and React projects.
+**Vercel** was built by the creators of Next.js. Great developer experience, fast CDN, similar free tier. Particularly good for Next.js and React projects.
 
-GitHub Pages provides free hosting directly from a GitHub repository. More limited than Netlify or Vercel, but zero configuration for simple projects. Good for portfolios and documentation.
+**GitHub Pages** provides free hosting directly from a GitHub repository. More limited than Netlify or Vercel, but zero configuration for simple projects. Good for portfolios and documentation.
 
-All three follow the same pattern: connect your repo, set the build command (npm run build) and publish directory (dist), and every push to main automatically builds and deploys. This is called continuous deployment: you push code, it goes live.
+All three follow the same pattern: connect your repo, set the build command (`npm run build`) and publish directory (`dist`), and every push to `main` automatically builds and deploys. This is called continuous deployment: you push code, it goes live.
 
 ## Your First Deploy
 
 Let us walk through the Netlify workflow, since it is what we use:
 
-1. Sign up at netlify.com with your GitHub account.
+1. Click "Add new site" → "Import an existing project" → select GitHub.
 
-2. Click "Add new site" → "Import an existing project" → select GitHub.
+2. Pick the repository you want to deploy from the list of your existing GitHub repos.
 
-3. Pick the repository you want to deploy from the list of your existing Github repos.
+3. Set the build command: `npm run build`.
 
-4. Set the build command: npm run build.
+4. Set the publish directory: `dist` (or `build`, depending on your tool).
 
-5. Set the publish directory: dist (or build, depending on your tool).
+5. Click "Deploy." Netlify clones your repo, runs the build, and publishes the output.
 
-6. Click "Deploy." Netlify clones your repo, runs the build, and publishes the output.
+In about 90 seconds, you have a live URL like `your-project-name.netlify.app`. That is it. Your project is on the internet.
 
-In about 90 seconds, you have a live URL like your-project-name.netlify.app. That is it. Your project is on the internet.
-
-From this point on, every time you push to main, Netlify rebuilds and redeploys automatically. You do not need to manually deploy again. Push code → it goes live.
-
-## Custom Domains
-
-The auto-generated URL (your-project.netlify.app) works, but for real projects you want your own domain. The process is straightforward:
-
-1. Buy a domain from a registrar (Namecheap, Cloudflare, Google Domains).
-
-2. In Netlify, go to Site settings → Domain management → Add custom domain.
-
-3. Netlify tells you what DNS records to set (we cover DNS in the next lesson).
-
-4. Set those records at your registrar. Wait for propagation.
-
-5. Netlify automatically provisions an SSL certificate (HTTPS). Your site is live on your domain, with encryption, for free.
+From this point on, every time you push to `main`, Netlify rebuilds and redeploys automatically. You do not need to manually deploy again. Push code → it goes live.
 
 ## When Deployment Fails
 
 Your deploy will fail eventually. This is normal. The build log tells you exactly what went wrong.
 
-The most common failures: a missing dependency (you installed something locally but forgot to save it to package.json), a build error (something in your code that works in development but fails in production), or an environment variable that is set locally but not on the hosting platform.
+The most common failures: a missing dependency (you installed something locally but forgot to save it to `package.json`), a build error (something in your code that works in development but fails in production), or an environment variable that is set locally but not on the hosting platform.
 
 Read the build log from the bottom up. The last error is usually the cause. Fix it, push again, and the platform rebuilds automatically. This loop (push, fail, read the log, fix, push again) is completely normal. Even experienced developers go through it.
 
 :::exercise{title="Deploy Something"}
-If you have a project with a package.json and a build command, deploy it to Netlify following the steps above. If you do not have a project yet, create the simplest possible one: make a folder, run npm create vite@latest my-site -- --template vanilla, cd into it, push to a new GitHub repo, and deploy that. The goal is not a polished product. It is experiencing the act of going from local to live. Get something on the internet. You can always improve it later.
+If you have a project with a `package.json` and a build command, deploy it to Netlify following the steps above. If you do not have a project yet, create the simplest possible one:
+
+- Run `npm create vite@latest my-site -- --template vanilla`
+- `cd my-site` and run `npm install`
+- Initialize a repo: `git init && git add . && git commit -m "Initial commit"`
+- Create a new repository on GitHub and push to it
+- Follow the "Your First Deploy" steps above to connect the repo to Netlify
+
+The goal is not a polished product. It is experiencing the act of going from local to live. Get something on the internet. You can always improve it later.
+:::
+
+:::extracredit{title="Custom Domains"}
+The auto-generated URL (`your-project.netlify.app`) works, but for real projects you want your own domain. The process is straightforward:
+
+- Buy a domain from a registrar (Namecheap, Cloudflare, Google Domains).
+- In Netlify, go to Site settings → Domain management → Add custom domain.
+- Netlify tells you what DNS records to set (we cover DNS in the next lesson).
+- Set those records at your registrar. Wait for propagation.
+- Netlify automatically provisions an SSL certificate (HTTPS). Your site is live on your domain, with encryption, for free.
 :::
 
 :::resources{title="Go Deeper"}

--- a/content/curriculum/00-orientation/deployment.md
+++ b/content/curriculum/00-orientation/deployment.md
@@ -113,16 +113,6 @@ If you have a project with a `package.json` and a build command, deploy it to Ne
 The goal is not a polished product. It is experiencing the act of going from local to live. Get something on the internet. You can always improve it later.
 :::
 
-:::extracredit{title="Custom Domains"}
-The auto-generated URL (`your-project.netlify.app`) works, but for real projects you want your own domain. The process is straightforward:
-
-- Buy a domain from a registrar (Namecheap, Cloudflare, Google Domains).
-- In Netlify, go to Site settings → Domain management → Add custom domain.
-- Netlify tells you what DNS records to set (we cover DNS in the next lesson).
-- Set those records at your registrar. Wait for propagation.
-- Netlify automatically provisions an SSL certificate (HTTPS). Your site is live on your domain, with encryption, for free.
-:::
-
 :::resources{title="Go Deeper"}
 - [Netlify Docs: Get Started](https://docs.netlify.com/get-started/). Step-by-step guide to deploying your first site on Netlify.
 - [Vercel Docs: Deployments](https://vercel.com/docs/deployments/overview). Vercel's deployment concepts explained clearly.

--- a/content/curriculum/00-orientation/deployment.md
+++ b/content/curriculum/00-orientation/deployment.md
@@ -106,7 +106,8 @@ If you have a project with a `package.json` and a build command, deploy it to Ne
 - Run `npm create vite@latest my-site -- --template vanilla`
 - `cd my-site` and run `npm install`
 - Initialize a repo: `git init && git add . && git commit -m "Initial commit"`
-- Create a new repository on GitHub and push to it
+- Go to [github.com/new](https://github.com/new) and create a new repository (give it any name, leave everything else as default — do not initialize with a README)
+- GitHub will show you setup instructions — copy the two lines under "push an existing repository from the command line" and run them in your terminal
 - Follow the "Your First Deploy" steps above to connect the repo to Netlify
 
 The goal is not a polished product. It is experiencing the act of going from local to live. Get something on the internet. You can always improve it later.

--- a/src/components/learn/MarkdownRenderer.jsx
+++ b/src/components/learn/MarkdownRenderer.jsx
@@ -38,17 +38,6 @@ function PrereqBlock({ children, title }) {
   );
 }
 
-/** Custom component: Extra Credit block */
-function ExtraCreditBlock({ children, title }) {
-  return (
-    <div className="ovl-block ovl-block-extracredit">
-      <div className="ovl-extracredit-label">Extra Credit</div>
-      {title && <h3 className="ovl-extracredit-title">{title}</h3>}
-      <div className="ovl-extracredit-body">{children}</div>
-    </div>
-  );
-}
-
 /** Custom component: Exercise block */
 function ExerciseBlock({ children, title }) {
   return (
@@ -130,7 +119,6 @@ const components = {
 
   // Custom directive components
   prereq: PrereqBlock,
-  extracredit: ExtraCreditBlock,
   exercise: ExerciseBlock,
   'template-block': TemplateBlock,
   step: StepBlock,

--- a/src/components/learn/MarkdownRenderer.jsx
+++ b/src/components/learn/MarkdownRenderer.jsx
@@ -28,12 +28,23 @@ function extractText(children) {
   return '';
 }
 
-/** Custom component: Prerequisite block (used inside exercise blocks) */
+/** Custom component: Prerequisite block */
 function PrereqBlock({ children, title }) {
   return (
-    <div className="ovl-exercise-prereq">
+    <div className="ovl-block ovl-block-prereq">
       <div className="ovl-prereq-label">{title || 'Before you start'}</div>
       <div className="ovl-prereq-body">{children}</div>
+    </div>
+  );
+}
+
+/** Custom component: Extra Credit block */
+function ExtraCreditBlock({ children, title }) {
+  return (
+    <div className="ovl-block ovl-block-extracredit">
+      <div className="ovl-extracredit-label">Extra Credit</div>
+      {title && <h3 className="ovl-extracredit-title">{title}</h3>}
+      <div className="ovl-extracredit-body">{children}</div>
     </div>
   );
 }
@@ -119,6 +130,7 @@ const components = {
 
   // Custom directive components
   prereq: PrereqBlock,
+  extracredit: ExtraCreditBlock,
   exercise: ExerciseBlock,
   'template-block': TemplateBlock,
   step: StepBlock,

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -2240,12 +2240,13 @@ a:hover {
   border-radius: 4px;
 }
 
-.ovl-exercise-prereq {
-  background: rgba(0, 230, 138, 0.05);
-  border: 1px solid rgba(0, 230, 138, 0.2);
+.ovl-block-prereq {
+  margin: 36px 0;
+  padding: 24px;
+  border: 1px solid rgba(255, 208, 0, 0.3);
+  border-left: 3px solid var(--color-yellow);
+  background: rgba(255, 208, 0, 0.04);
   border-radius: 4px;
-  padding: 16px 20px;
-  margin-bottom: 20px;
 }
 
 .ovl-prereq-label {
@@ -2253,8 +2254,8 @@ a:hover {
   font-size: 11px;
   font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: rgba(0, 230, 138, 0.8);
+  letter-spacing: 0.1em;
+  color: var(--color-yellow);
   margin-bottom: 8px;
 }
 
@@ -2274,6 +2275,33 @@ a:hover {
 }
 
 .ovl-exercise-title {
+  font-family: var(--font-display);
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--ovl-text);
+  margin-bottom: 8px;
+}
+
+.ovl-block-extracredit {
+  margin: 36px 0;
+  padding: 24px;
+  border: 1px solid rgba(168, 85, 247, 0.3);
+  border-left: 3px solid var(--color-purple);
+  background: rgba(168, 85, 247, 0.04);
+  border-radius: 4px;
+}
+
+.ovl-extracredit-label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--color-purple);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+
+.ovl-extracredit-title {
   font-family: var(--font-display);
   font-size: 1.1rem;
   font-weight: 700;

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -2282,33 +2282,6 @@ a:hover {
   margin-bottom: 8px;
 }
 
-.ovl-block-extracredit {
-  margin: 36px 0;
-  padding: 24px;
-  border: 1px solid rgba(168, 85, 247, 0.3);
-  border-left: 3px solid var(--color-purple);
-  background: rgba(168, 85, 247, 0.04);
-  border-radius: 4px;
-}
-
-.ovl-extracredit-label {
-  font-family: var(--font-mono);
-  font-size: 11px;
-  font-weight: 600;
-  color: var(--color-purple);
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  margin-bottom: 8px;
-}
-
-.ovl-extracredit-title {
-  font-family: var(--font-display);
-  font-size: 1.1rem;
-  font-weight: 700;
-  color: var(--ovl-text);
-  margin-bottom: 8px;
-}
-
 .ovl-block-code {
   margin: 36px 0;
   background: #0a0a0a;

--- a/src/utils/remark-custom-directives.js
+++ b/src/utils/remark-custom-directives.js
@@ -9,7 +9,6 @@
  *   :::template{title="..."}  → <template-block title="..."> (content treated as raw text)
  *   :::step{number="01" title="..."} → <step number="01" title="...">
  *   :::resources{title="..."}  → <resources title="...">
- *   :::extracredit{title="..."}  → <extracredit title="...">
  */
 
 import { visit } from 'unist-util-visit';
@@ -62,7 +61,6 @@ export function remarkCustomDirectives() {
           step: 'step',
           resources: 'resources',
           prereq: 'prereq',
-          extracredit: 'extracredit',
         };
 
         // Only process directives we explicitly support.

--- a/src/utils/remark-custom-directives.js
+++ b/src/utils/remark-custom-directives.js
@@ -9,6 +9,7 @@
  *   :::template{title="..."}  → <template-block title="..."> (content treated as raw text)
  *   :::step{number="01" title="..."} → <step number="01" title="...">
  *   :::resources{title="..."}  → <resources title="...">
+ *   :::extracredit{title="..."}  → <extracredit title="...">
  */
 
 import { visit } from 'unist-util-visit';
@@ -61,6 +62,7 @@ export function remarkCustomDirectives() {
           step: 'step',
           resources: 'resources',
           prereq: 'prereq',
+          extracredit: 'extracredit',
         };
 
         // Only process directives we explicitly support.


### PR DESCRIPTION
## Summary

- Add `:::prereq` block at top of lesson for GitHub credentials and Netlify account setup (closes #28)
- Move Custom Domains section to new `:::extracredit` directive after the exercise (closes #29)
- Add `:::extracredit` directive with purple styling (new component, CSS, remark plugin registration)
- Restyle `:::prereq` as standalone yellow block matching other directive styles
- Reformat exercise as bulleted list with expanded GitHub repo creation steps
- Apply inline code formatting throughout
- Bold hosting platform names for scannability

## Test plan

- [ ] `npm run build` passes
- [ ] Prereq block renders at top of lesson with yellow border-left
- [ ] Exercise renders as bulleted list
- [ ] Extra Credit block renders with purple border-left and "Custom Domains" title
- [ ] Resources block renders normally after extra credit

🤖 Generated with [Claude Code](https://claude.com/claude-code)