### PR TITLE
fix(completion-card): repair share-button behavior

### DIFF
--- a/src/components/learn/CompletionCard.jsx
+++ b/src/components/learn/CompletionCard.jsx
@@ -11,7 +11,7 @@ function CompletionCard({ level }) {
   if (percent < 100) return null;
 
   const shareText = `I completed ${level.number} ${level.title} on the Open Vector — the free Zero-Vector Design curriculum.`;
-  const shareUrl = `https://zerovector.design/learn/curriculum/${level.slug}`;
+  const shareUrl = `https://open.zerovector.design/learn/curriculum/${level.slug}`;
 
   function handleCopy() {
     navigator.clipboard.writeText(`${shareText}\n${shareUrl}`).then(() => {

--- a/src/components/learn/CompletionCard.jsx
+++ b/src/components/learn/CompletionCard.jsx
@@ -14,14 +14,14 @@ function CompletionCard({ level }) {
   const shareUrl = `https://open.zerovector.design/learn/curriculum/${level.slug}`;
 
   function handleCopy() {
-    navigator.clipboard.writeText(`${shareText}\n${shareUrl}`).then(() => {
+    navigator.clipboard.writeText(shareUrl).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     });
   }
 
   function handleLinkedIn() {
-    const url = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(shareUrl)}`;
+    const url = `https://www.linkedin.com/feed/?shareActive=true&text=${encodeURIComponent(`${shareText} ${shareUrl}`)}`;
     window.open(url, '_blank', 'width=600,height=400');
   }
 


### PR DESCRIPTION
## Summary
Three related bug fixes to `src/components/learn/CompletionCard.jsx` (the level-completion share buttons):

1. **Wrong domain in share URL.** Was `https://zerovector.design/...` (the manifesto site). Now `https://open.zerovector.design/...` (where the curriculum lives). LinkedIn was fetching the manifesto site's 404 for its preview card and sharing the 404 link with no message.
2. **Copy Link copied too much.** `handleCopy` was writing `${shareText}\n${shareUrl}` to the clipboard. A "Copy Link" button should copy a link, not a paragraph. Now copies only the URL.
3. **LinkedIn share had no message.** `handleLinkedIn` was using `share-offsite`, which only takes a URL and pulls all rendered text from the destination's Open Graph tags. Switched to LinkedIn's feed-composer endpoint (`/feed/?shareActive=true&text=...`), which opens a post composer with the message + URL prefilled. LinkedIn auto-detects the URL in the text and renders the preview card.

Closes #33

## Test plan
- [ ] Complete a level. Click "LinkedIn" — confirm the LinkedIn composer opens with the "I completed... on the Open Vector..." message prefilled, the URL is included, and the preview card resolves to the correct level page (not a 404).
- [ ] Click "X / Twitter" — confirm the tweet composer shows the message and the link resolves to `open.zerovector.design`.
- [ ] Click "Copy Link" — confirm the clipboard contains only the URL (no leading message), and that the URL points to `open.zerovector.design`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)