### PR TITLE
fix(curriculum): formatting sweep (issue #14) + consolidated level-01 PRs

### DIFF
--- a/content/curriculum/00-orientation/deployment.md
+++ b/content/curriculum/00-orientation/deployment.md
@@ -49,7 +49,7 @@ This is the build step. You run a command, usually `npm run build`, and your bui
 
 The `dist/` folder is what gets deployed. Not your source code, not your `node_modules`, not your `.env` file. Just the clean, compiled output. This is why deployment and development are separate steps: what you work with is not what you ship.
 
-```
+```bash
 # Build your project for production
 npm run build
 

--- a/content/curriculum/00-orientation/dns.md
+++ b/content/curriculum/00-orientation/dns.md
@@ -99,7 +99,7 @@ You can also check specific record types: `dig zerovector.design CNAME` or `dig 
 
 There are also web-based tools like [dnschecker.org](https://dnschecker.org) that show you what DNS servers around the world are reporting for your domain. This is useful during propagation to see how far your change has spread.
 
-```
+```bash
 # Look up the A record for a domain
 dig zerovector.design
 

--- a/content/curriculum/00-orientation/git-basics.md
+++ b/content/curriculum/00-orientation/git-basics.md
@@ -67,7 +67,7 @@ git commit -m "Add landing page layout and base styles"
 
 `git diff` shows what changed. Shows the exact lines that were added, removed, or modified since your last commit. Invaluable for reviewing your work before committing.
 
-```
+```bash
 git init                          # Start tracking this folder
 git status                        # What has changed?
 git add .                         # Stage all changes

--- a/content/curriculum/00-orientation/repos.md
+++ b/content/curriculum/00-orientation/repos.md
@@ -31,7 +31,7 @@ This is how you get started with other people's code. Found an interesting open 
 
 After cloning, you have a fully independent copy. You can edit files, make commits, and experiment without affecting the original. If the repo is yours or you have been given access, you can push changes back to the remote. If it is someone else's public repo, you can create your own remote on GitHub and push there instead, making the project your own. You will do exactly this later in the curriculum.
 
-```
+```bash
 # Clone a repository from GitHub
 git clone https://github.com/username/project-name.git
 
@@ -83,7 +83,7 @@ If you created a repo locally (`git init`) instead of cloning, you need to conne
 
 In these commands, `origin` is the default name Git gives your remote connection, and `main` is the primary branch where your work lives.
 
-```
+```bash
 # Push your commits to the remote
 git push origin main
 

--- a/content/curriculum/00-orientation/terminal.md
+++ b/content/curriculum/00-orientation/terminal.md
@@ -82,7 +82,7 @@ You do not need to memorize a hundred commands. You need about ten. Here are the
 
 `clear` clears your screen. Does not delete anything. Just tidies up.
 
-```
+```bash
 pwd                     # Where am I?
 ls                      # What is here?
 cd my-project           # Go into my-project

--- a/content/curriculum/00-orientation/what-is-zero-vector.md
+++ b/content/curriculum/00-orientation/what-is-zero-vector.md
@@ -84,7 +84,7 @@ Make sure you have:
 You do not need prior coding experience. You do not need a computer science degree. You do not need to know what a terminal is yet. That is what the next lesson teaches.
 :::
 
-:::resources{title="Links"}
+:::resources{title="Go Deeper"}
 - [Zero Vector Design](https://zerovector.design). The Zero Vector Design home.
 - [The Zero Vector Manifesto](https://zerovector.design/philosophy). The philosophy in full.
 - [Substack: Erika Flowers](https://eflowers.substack.com). Essays on the methodology and the movement.

--- a/content/curriculum/01-foundation/architecture.md
+++ b/content/curriculum/01-foundation/architecture.md
@@ -74,9 +74,9 @@ This sounds abstract until you build something with state in the wrong place. Th
 
 Let us trace the architecture of a real application, a site like Zero Vector:
 
-The source code lives in src/. Inside, pages/ contains one file per route. components/ contains reusable pieces. styles/ contains CSS. content/ contains the text and data. This is separation of concerns at the file level.
+The source code lives in `src/`. Inside, `pages/` contains one file per route. `components/` contains reusable pieces. `styles/` contains CSS. `content/` contains the text and data. This is separation of concerns at the file level.
 
-The router maps URLs to pages: /learn/curriculum/00-orientation/terminal shows the LessonPage component with data from the terminal lesson file. The URL is the single source of truth; no hidden state decides what you see.
+The router maps URLs to pages: `/learn/curriculum/00-orientation/terminal` shows the `LessonPage` component with data from the terminal lesson file. The URL is the single source of truth; no hidden state decides what you see.
 
 The layout components (navigation, sidebar) wrap the content. They do not know what content is inside them. The content components do not know what layout surrounds them. They communicate through well-defined props and context.
 
@@ -89,7 +89,13 @@ Zero Vector practitioners design the architecture before the first prompt. This 
 Why does this matter so much with AI agents? Because an agent will happily build whatever you ask for, even if it contradicts what you asked for yesterday. Without architecture, you end up with a codebase that is a patchwork of disconnected decisions. With architecture, every piece the agent builds fits into a coherent whole. The architecture is your blueprint. The agent is the builder. Builders without blueprints make sheds, not houses.
 
 :::exercise{title="Sketch Before You Build"}
-Think of a simple app (a to-do list, a recipe collection, a bookmark manager). Before writing any code, sketch its architecture on paper. Draw three boxes: frontend, backend, database. In each box, list what it is responsible for. Draw arrows showing what data flows between them. Now zoom into the frontend: draw the main components (layout, navigation, list, form, detail view). Draw arrows showing how data flows between them. Where does state live? This 10-minute sketch will save you hours of refactoring.
+- Think of a simple app (a to-do list, a recipe collection, a bookmark manager)
+- Before writing any code, sketch its architecture on paper
+- Draw three boxes: frontend, backend, database. In each box, list what it is responsible for
+- Draw arrows showing what data flows between them
+- Now zoom into the frontend: draw the main components (layout, navigation, list, form, detail view)
+- Draw arrows showing how data flows between them. Where does state live?
+- This 10-minute sketch will save you hours of refactoring.
 :::
 
 :::resources{title="Go Deeper"}

--- a/content/curriculum/01-foundation/data-modeling.md
+++ b/content/curriculum/01-foundation/data-modeling.md
@@ -95,7 +95,7 @@ JSON has two structures: objects (key-value pairs, wrapped in curly braces) and 
 
 Understanding JSON means you can read any API response, any config file, and any data structure in your application. It is the shape of modern web data.
 
-```
+```json
 // A recipe as JSON — this is what an API sends to the frontend:
 {
   "id": "rec_001",

--- a/content/curriculum/01-foundation/data-modeling.md
+++ b/content/curriculum/01-foundation/data-modeling.md
@@ -22,7 +22,7 @@ This is why experienced engineers start with the data model before writing a sin
 
 An entity is a thing your application tracks. If you did the Nouns & Verbs exercise, your core nouns are your entities. A Recipe is an entity. A User is an entity. An Order is an entity.
 
-Each entity has fields: the specific pieces of information you store about it. A Recipe entity might have: title (text), description (text), cookTime (number, in minutes), servings (number), createdAt (date), authorId (reference to a User).
+Each entity has fields: the specific pieces of information you store about it. A Recipe entity might have: `title` (text), `description` (text), `cookTime` (number, in minutes), `servings` (number), `createdAt` (date), `authorId` (reference to a User).
 
 Choosing the right fields is a design decision. Do you store cooking time as a single number (minutes) or as two fields (hours and minutes)? Do you store the author's name directly on the recipe, or just a reference to their user profile? Each choice has consequences.
 
@@ -59,7 +59,7 @@ Collection
 
 Entities do not exist in isolation. They are connected. Understanding these connections is the core of data modeling.
 
-One-to-many: One user can create many recipes, but each recipe has exactly one author. The recipe stores a reference to the user (authorId). This is the most common relationship in software.
+One-to-many: One user can create many recipes, but each recipe has exactly one author. The recipe stores a reference to the user (`authorId`). This is the most common relationship in software.
 
 Many-to-many: A recipe can belong to many collections, and a collection can contain many recipes. Neither side "owns" the other. This usually requires a join table, a third table that tracks which recipes are in which collections.
 
@@ -71,7 +71,7 @@ When you draw your data model on paper, draw lines between entities. Write "1" o
 
 Every field has a type: text, number, date, boolean (true/false), array (list). Choosing the right type prevents entire categories of bugs.
 
-If cookTime is a number, nobody can accidentally store "about thirty minutes" in it. If email has a uniqueness constraint, no two users can register with the same address. If servings has a minimum of 1, you cannot create a recipe for zero people.
+If `cookTime` is a number, nobody can accidentally store "about thirty minutes" in it. If `email` has a uniqueness constraint, no two users can register with the same address. If `servings` has a minimum of 1, you cannot create a recipe for zero people.
 
 Constraints are rules that your data must follow. They are enforced by the database, not by your application code. This matters because data can enter your system from many places: your UI, your API, a database migration, an import script. The database is the last line of defense.
 
@@ -130,7 +130,13 @@ In Zero Vector, your data model is one of the most important things you hand to 
 The inverse is equally true. A vague or inconsistent data model produces vague, inconsistent code. If your model has a "stuff" table with columns named "data1" through "data5," no AI agent in the world can build something coherent on top of it. The quality of your data model directly determines the quality of AI-generated code. Invest the thinking here, and the build phase gets dramatically easier.
 
 :::exercise{title="Model Your Project"}
-Take the project you planned in the Planning lesson (or the reading tracker). List every entity, the things your app needs to remember. For each entity, list its fields with types (title: string, pageCount: number, isFinished: boolean). Draw the relationships between entities: which ones reference each other? Mark each relationship as one-to-one, one-to-many, or many-to-many. Write one entity as a JSON object with sample data. You now have a data model. When you start building, this model becomes your database schema and your API contract.
+- Take the project you planned in the Planning lesson (or the reading tracker)
+- List every entity, the things your app needs to remember
+- For each entity, list its fields with types (`title: string`, `pageCount: number`, `isFinished: boolean`)
+- Draw the relationships between entities: which ones reference each other?
+- Mark each relationship as one-to-one, one-to-many, or many-to-many
+- Write one entity as a JSON object with sample data
+- You now have a data model. When you start building, this model becomes your database schema and your API contract.
 :::
 
 :::resources{title="Go Deeper"}

--- a/content/curriculum/01-foundation/information-architecture.md
+++ b/content/curriculum/01-foundation/information-architecture.md
@@ -29,7 +29,7 @@ On the web, IA is your site structure, your navigation, your URLs, your headings
 
 If you are coming from design, you already think about IA: navigation menus, page hierarchy, content grouping. But when you start building, IA becomes structural. Your folder structure is IA. Your URL scheme is IA. Your component hierarchy is IA.
 
-Consider this URL: /learn/curriculum/01-foundation/information-architecture. That path tells you exactly where you are: you are in the Open Vector section, in the Learn area, in the Curriculum, in the Foundation level, reading the Information Architecture lesson. The URL is not just an address. It is a map.
+Consider this URL: `/learn/curriculum/01-foundation/information-architecture`. That path tells you exactly where you are: you are in the Open Vector section, in the Learn area, in the Curriculum, in the Foundation level, reading the Information Architecture lesson. The URL is not just an address. It is a map.
 
 When your IA is solid, everything downstream benefits. Navigation writes itself. Breadcrumbs work automatically. Search indexing is clean. Users build accurate mental models of your site. When IA is weak, you end up with a flat mess of pages, confusing navigation, and users who cannot find what they saw five minutes ago.
 
@@ -69,11 +69,11 @@ These three patterns together (global, local, breadcrumbs) give users full spati
 
 In web applications, URLs are a direct expression of your information architecture. A well-structured URL scheme is readable, predictable, and hierarchical.
 
-/products/shoes/running: you know exactly what you will find. You can edit the URL to /products/shoes and see all shoes. You can go to /products and see all product categories. The URL is navigable.
+`/products/shoes/running`: you know exactly what you will find. You can edit the URL to `/products/shoes` and see all shoes. You can go to `/products` and see all product categories. The URL is navigable.
 
-/app?view=3&tab=2&id=a7f3e: you know nothing. You cannot edit it meaningfully. You cannot share it with someone and have them understand what it points to.
+`/app?view=3&tab=2&id=a7f3e`: you know nothing. You cannot edit it meaningfully. You cannot share it with someone and have them understand what it points to.
 
-When you design your routes, think of them as an outline. Each segment adds specificity. /blog is all posts. /blog/2026 is posts from this year. /blog/2026/systems-thinking is a specific post. The URL tells a story.
+When you design your routes, think of them as an outline. Each segment adds specificity. `/blog` is all posts. `/blog/2026` is posts from this year. `/blog/2026/systems-thinking` is a specific post. The URL tells a story.
 
 ```
 # Good URL architecture — readable, hierarchical, predictable:
@@ -110,7 +110,14 @@ Information architecture in Zero Vector extends beyond the user interface. It ap
 An agent reading a project with clear information architecture (components grouped by domain, services separated from UI, utilities in a predictable location) can find what it needs and place new code where it belongs. An agent reading a project that grew organically with no IA will scatter new files randomly, duplicate existing utilities it could not find, and create the kind of structural debt that compounds with every session. Your project's IA is not just for human developers anymore. It is for your entire crew.
 
 :::exercise{title="Audit an IA You Use"}
-Pick a website you use regularly, not one you have built. Open it and write down the top-level navigation items. For each one, try to predict what you will find inside before clicking. Now click. Were you right? Were you surprised? Find one label that could be clearer. Find one piece of content that feels like it is in the wrong section. Sketch a URL scheme that would make the site structure obvious. You have just done an IA audit. This is how you build the instinct for good information architecture.
+- Pick a website you use regularly, not one you have built
+- Open it and write down the top-level navigation items
+- For each one, try to predict what you will find inside before clicking
+- Now click. Were you right? Were you surprised?
+- Find one label that could be clearer
+- Find one piece of content that feels like it is in the wrong section
+- Sketch a URL scheme that would make the site structure obvious
+- You have just done an IA audit. This is how you build the instinct for good information architecture.
 :::
 
 :::resources{title="Go Deeper"}

--- a/content/curriculum/01-foundation/nouns-and-verbs.md
+++ b/content/curriculum/01-foundation/nouns-and-verbs.md
@@ -94,7 +94,7 @@ System verbs are actions the system performs without user input: validate (check
 
 This exercise is especially powerful when working with AI coding tools. The better you can describe what you are building in structured language, the better your AI collaborator can help.
 
-Instead of telling Claude Code "build me a recipe app," you can say: "I need a Recipe data model with title, ingredients (array of strings), steps (array of strings), cookTime (integer, minutes), and authorId (foreign key to Users). Create a REST API with endpoints for creating, reading, updating, and deleting recipes. Add a search endpoint that filters by ingredient."
+Instead of telling Claude Code "build me a recipe app," you can say: "I need a `Recipe` data model with `title`, `ingredients` (array of strings), `steps` (array of strings), `cookTime` (integer, minutes), and `authorId` (foreign key to `Users`). Create a REST API with endpoints for creating, reading, updating, and deleting recipes. Add a search endpoint that filters by ingredient."
 
 That prompt came directly from the Nouns & Verbs exercise. You identified the nouns (Recipe, with its fields), identified the verbs (create, read, update, delete, search), and translated them into specific technical requirements. The AI now has clear instructions instead of vibes.
 
@@ -105,7 +105,14 @@ In Zero Vector, nouns and verbs become the foundation of your data model and you
 This matters because AI agents are remarkably good at building CRUD operations, API endpoints, and database schemas when the entities are well-defined. They struggle when the entities are fuzzy. "Build me a recipe app" produces mediocre results. "Build me an app with Recipes, Ingredients, Collections, and Shopping Lists, where users can scale recipes, search by ingredient, and generate shopping lists from selected recipes" produces something you can actually ship. The nouns and verbs are the prompt.
 
 :::exercise{title="Extract Your Architecture"}
-Think of a project you want to build, or use this prompt: "A personal finance tracker where users log expenses, categorize spending, set monthly budgets, and view reports showing where their money goes." Write two or three sentences describing it. Underline every noun. Underline every verb. List the nouns on the left side of a page and the verbs on the right. Draw lines connecting verbs to the nouns they act on. Now look at your nouns list; those are your database tables. Look at your verbs list; those are your features. You just designed the skeleton of an application in five minutes.
+- Think of a project you want to build, or use this prompt: "A personal finance tracker where users log expenses, categorize spending, set monthly budgets, and view reports showing where their money goes."
+- Write two or three sentences describing it
+- Underline every noun. Underline every verb.
+- List the nouns on the left side of a page and the verbs on the right
+- Draw lines connecting verbs to the nouns they act on
+- Now look at your nouns list; those are your database tables
+- Look at your verbs list; those are your features
+- You just designed the skeleton of an application in five minutes.
 :::
 
 :::resources{title="Go Deeper"}

--- a/content/curriculum/01-foundation/systems-thinking.md
+++ b/content/curriculum/01-foundation/systems-thinking.md
@@ -78,7 +78,12 @@ In Zero Vector, systems thinking is the prerequisite for everything. Before you 
 This is what separates a Zero Vector practitioner from someone copy-pasting prompts. You understand the forces acting on the system. You see the feedback loops, the dependencies, the second-order effects. When you direct an agent with that understanding, the output is coherent. Without it, you get code that technically works but does not fit together.
 
 :::exercise{title="Map a System You Use Every Day"}
-Pick an app you use daily (a music streaming service, a food delivery app, a social media platform). On paper (or a whiteboard), draw the major parts: the user, the content, the recommendation engine, the payment system, the content creators. Now draw arrows showing how they connect. What flows between them? Data? Money? Attention? Find one feedback loop in your diagram. Find one dependency chain (A needs B which needs C). You have just done systems thinking. This is the skill: seeing connections, not just parts.
+- Pick an app you use daily (a music streaming service, a food delivery app, a social media platform)
+- On paper (or a whiteboard), draw the major parts: the user, the content, the recommendation engine, the payment system, the content creators
+- Now draw arrows showing how they connect. What flows between them? Data? Money? Attention?
+- Find one feedback loop in your diagram
+- Find one dependency chain (A needs B which needs C)
+- You have just done systems thinking. This is the skill: seeing connections, not just parts.
 :::
 
 :::resources{title="Go Deeper"}

--- a/content/curriculum/01-foundation/vector-md.md
+++ b/content/curriculum/01-foundation/vector-md.md
@@ -55,7 +55,7 @@ Current State describes what exists right now. What is built, what is broken, wh
 
 > CLAUDE.md tells agents how to behave. VECTOR.md tells agents what they're building. Together, these two files form the complete context stack for AI-assisted development. The agent knows its role, its constraints, and its communication style (CLAUDE.md). And it knows the project, the users, and the architecture (VECTOR.md). You will learn about CLAUDE.md in Level 04.
 
-```
+```markdown
 # VECTOR.md — Recipe Keeper
 
 ## Project Overview
@@ -136,7 +136,7 @@ VECTOR.md is not a separate concept. It is the container for all the thinking yo
 Go to the Investiture scaffold repository at github.com/erikaflowers/investiture and find the VECTOR.md file. Open it and answer these questions: (1) What problem is the project solving? (2) Who are the users? (3) What architecture decisions were made, and what reasons are given? (4) What constraints are listed? (5) How does the Current State section help an AI agent who is reading this for the first time? You do not need to understand every technical term. Focus on the structure: how the document is organized, what information it prioritizes, and how it would help someone (or something) get up to speed quickly.
 :::
 
-:::resources{title="Links"}
+:::resources{title="Go Deeper"}
 - [Investiture Scaffold Repository](https://github.com/erikaflowers/investiture): A real VECTOR.md in a real project.
 - [Investiture Framework](https://zerovector.design/investiture): The Investiture framework page on Zero Vector.
 - [Zero Vector Substack](https://eflowers.substack.com): Articles on the methodology.

--- a/content/curriculum/01-foundation/vector-md.md
+++ b/content/curriculum/01-foundation/vector-md.md
@@ -21,23 +21,23 @@ You have spent the first four lessons of this level learning to think in systems
 
 In traditional software development, this thinking lives in Confluence pages nobody reads, in Figma files that drift from reality, in Slack threads that disappear into the void. The thinking happens, and then it evaporates.
 
-VECTOR.md is where it lives instead.
+`VECTOR.md` is where it lives instead.
 
-A VECTOR.md file is a single markdown document that captures your project's intent, architecture, and constraints in a format that both humans and AI agents can read. It is the written artifact of all the systems thinking and planning work you have been doing. One file. One source of truth. Always in the repo, always up to date, always informing every decision.
+A `VECTOR.md` file is a single markdown document that captures your project's intent, architecture, and constraints in a format that both humans and AI agents can read. It is the written artifact of all the systems thinking and planning work you have been doing. One file. One source of truth. Always in the repo, always up to date, always informing every decision.
 
 ## The Context Problem
 
 AI agents have no memory between sessions. Every time you start a conversation with an AI assistant, it knows nothing about your project, your users, your architecture decisions, or why you chose React over Svelte. You have to re-explain everything. Every. Single. Time.
 
-This is the fundamental problem VECTOR.md solves.
+This is the fundamental problem `VECTOR.md` solves.
 
-When an AI agent reads your VECTOR.md at the start of a session, it instantly has the context it needs: who the users are, what problem you are solving, what architecture decisions have been made, what constraints exist, what has already been built. The agent goes from blank slate to informed collaborator in seconds.
+When an AI agent reads your `VECTOR.md` at the start of a session, it instantly has the context it needs: who the users are, what problem you are solving, what architecture decisions have been made, what constraints exist, what has already been built. The agent goes from blank slate to informed collaborator in seconds.
 
-But VECTOR.md is not just for AI agents. It is for you. It forces you to articulate your thinking clearly enough that a machine can understand it. And if a machine can understand it, that means your thinking is precise. Vague ideas hiding in your head become concrete decisions on the page.
+But `VECTOR.md` is not just for AI agents. It is for you. It forces you to articulate your thinking clearly enough that a machine can understand it. And if a machine can understand it, that means your thinking is precise. Vague ideas hiding in your head become concrete decisions on the page.
 
-## What Goes in a VECTOR.md?
+## What Goes in a `VECTOR.md`?
 
-A VECTOR.md typically contains these sections (though every project adapts the format to its needs):
+A `VECTOR.md` typically contains these sections (though every project adapts the format to its needs):
 
 Project Overview captures what you are building and why. Not a marketing pitch. A clear, honest description of the problem you are solving and the approach you are taking.
 
@@ -53,7 +53,7 @@ Constraints captures what you cannot or will not do. Budget limits, timeline, te
 
 Current State describes what exists right now. What is built, what is broken, what is next. This section changes frequently and keeps everyone (including AI agents) oriented.
 
-> CLAUDE.md tells agents how to behave. VECTOR.md tells agents what they're building. Together, these two files form the complete context stack for AI-assisted development. The agent knows its role, its constraints, and its communication style (CLAUDE.md). And it knows the project, the users, and the architecture (VECTOR.md). You will learn about CLAUDE.md in Level 04.
+> `CLAUDE.md` tells agents how to behave. `VECTOR.md` tells agents what they're building. Together, these two files form the complete context stack for AI-assisted development. The agent knows its role, its constraints, and its communication style (`CLAUDE.md`). And it knows the project, the users, and the architecture (`VECTOR.md`). You will learn about `CLAUDE.md` in Level 04.
 
 ```markdown
 # VECTOR.md — Recipe Keeper
@@ -120,7 +120,7 @@ friendly.
 
 ## How This Connects to What You've Learned
 
-Look at that example VECTOR.md again. Every section maps to something you have already studied in this level:
+Look at that example `VECTOR.md` again. Every section maps to something you have already studied in this level:
 
 Systems Thinking (Lesson 1) taught you to see the whole system before zooming into parts. The Project Overview and Architecture sections capture that systems-level view.
 
@@ -130,14 +130,21 @@ Nouns & Verbs (Lesson 3) taught you to identify the core entities and actions. T
 
 Planning (Lesson 4) taught you to sequence work and identify dependencies. The Current State section keeps that plan honest by tracking reality.
 
-VECTOR.md is not a separate concept. It is the container for all the thinking you have been learning to do. The artifact that holds the architecture, the plan, and the intent in one place.
+`VECTOR.md` is not a separate concept. It is the container for all the thinking you have been learning to do. The artifact that holds the architecture, the plan, and the intent in one place.
 
 :::exercise{title="Read a VECTOR.md"}
-Go to the Investiture scaffold repository at github.com/erikaflowers/investiture and find the VECTOR.md file. Open it and answer these questions: (1) What problem is the project solving? (2) Who are the users? (3) What architecture decisions were made, and what reasons are given? (4) What constraints are listed? (5) How does the Current State section help an AI agent who is reading this for the first time? You do not need to understand every technical term. Focus on the structure: how the document is organized, what information it prioritizes, and how it would help someone (or something) get up to speed quickly.
+- Go to the Investiture scaffold repository at github.com/erikaflowers/investiture and find the `VECTOR.md` file
+- Open it and answer these questions:
+  - What problem is the project solving?
+  - Who are the users?
+  - What architecture decisions were made, and what reasons are given?
+  - What constraints are listed?
+  - How does the Current State section help an AI agent who is reading this for the first time?
+- You do not need to understand every technical term. Focus on the structure: how the document is organized, what information it prioritizes, and how it would help someone (or something) get up to speed quickly.
 :::
 
 :::resources{title="Go Deeper"}
-- [Investiture Scaffold Repository](https://github.com/erikaflowers/investiture): A real VECTOR.md in a real project.
+- [Investiture Scaffold Repository](https://github.com/erikaflowers/investiture): A real `VECTOR.md` in a real project.
 - [Investiture Framework](https://zerovector.design/investiture): The Investiture framework page on Zero Vector.
 - [Zero Vector Substack](https://eflowers.substack.com): Articles on the methodology.
 :::

--- a/content/curriculum/02-the-medium/claude-code.md
+++ b/content/curriculum/02-the-medium/claude-code.md
@@ -30,7 +30,7 @@ Claude Code runs in your terminal. You need Node.js installed (which you will ne
 
 The recommended way to install is with the official installer. Run the command below in your terminal. It handles permissions correctly and does not require sudo or admin access.
 
-```
+```bash
 # Install Claude Code (recommended)
 curl -fsSL https://claude.ai/install.sh | bash
 
@@ -42,7 +42,7 @@ Once installed, navigate to any project folder in your terminal and type claude 
 
 You may see older guides suggest npm install -g @anthropic-ai/claude-code. That still works, but on macOS it often fails with a permissions error because the global npm directory requires admin access. If you hit that, do not use sudo. Use the installer above instead. It avoids the permissions issue entirely and will not cause problems later.
 
-```
+```bash
 # Navigate to your project
 cd ~/my-project
 

--- a/content/curriculum/02-the-medium/deploy.md
+++ b/content/curriculum/02-the-medium/deploy.md
@@ -26,7 +26,7 @@ Your code is committed and pushed: The hosting platform deploys from your GitHub
 
 No secrets in the code: Check that .env is in your .gitignore. API keys, passwords, and tokens should never be committed. If they are, rotate them immediately.
 
-```
+```bash
 # The deploy checklist in terminal commands:
 
 # 1. Build successfully?
@@ -94,7 +94,12 @@ Build error: something in your code that works in dev but fails in production (o
 Read the error. Fix the cause. Push again. Netlify rebuilds automatically.
 
 :::exercise{title="Deploy Your Project"}
-Take the project you have been building (or create a fresh one with npm create vite@latest my-site -- --template react). Make sure it builds: npm run build. Create a GitHub repo and push your code. Sign up for Netlify, import the repo, set build command to "npm run build" and publish directory to "dist." Deploy. Click the URL. You are on the internet. Change something in your code, commit, push, and watch Netlify auto-deploy the update.
+- Take the project you have been building (or create a fresh one with `npm create vite@latest my-site -- --template react`).
+- Make sure it builds: `npm run build`.
+- Create a GitHub repo and push your code.
+- Sign up for Netlify, import the repo, set build command to `npm run build` and publish directory to `dist`.
+- Deploy. Click the URL. You are on the internet.
+- Change something in your code, commit, push, and watch Netlify auto-deploy the update.
 :::
 
 :::resources{title="Go Deeper"}

--- a/content/curriculum/02-the-medium/iteration.md
+++ b/content/curriculum/02-the-medium/iteration.md
@@ -73,7 +73,15 @@ With AI agents, divergent iteration is fast: "Show me three different approaches
 Know which mode you are in. Divergent iteration should feel exploratory and open. Convergent iteration should feel like polishing. If you are polishing too early (before the structure is right) or exploring too late (when you should be shipping), adjust.
 
 :::exercise{title="Build in Five Steps"}
-Pick a small component (a profile card, a pricing table, a testimonial block). Build it in exactly five prompts, committing after each one: (1) the basic structure and data, (2) the layout and spacing, (3) responsive behavior, (4) one interactive feature (hover state, expand/collapse, link), (5) final polish. After each prompt, check the browser and commit before continuing. Notice how each step builds cleanly on the last. This is the rhythm.
+- Pick a small component (a profile card, a pricing table, a testimonial block).
+- Build it in exactly five prompts, committing after each one:
+  - The basic structure and data.
+  - The layout and spacing.
+  - Responsive behavior.
+  - One interactive feature (hover state, expand/collapse, link).
+  - Final polish.
+- After each prompt, check the browser and commit before continuing.
+- Notice how each step builds cleanly on the last. This is the rhythm.
 :::
 
 :::resources{title="Go Deeper"}

--- a/content/curriculum/02-the-medium/prompting.md
+++ b/content/curriculum/02-the-medium/prompting.md
@@ -90,7 +90,11 @@ Do not skip review. The most dangerous pattern is prompt-approve-prompt-approve 
 Do not copy-paste prompts from the internet. Your project has specific context, conventions, and constraints. Generic prompts produce generic code that does not fit your project.
 
 :::exercise{title="Write Three Prompts"}
-Pick a feature you want to build (or use: a reading list with add/remove/mark-as-read). Write three prompts, each building on the last: (1) the data structure and initial component, (2) a specific interaction (adding a book), (3) a visual refinement (styling the list). For each prompt, include context, intent, and at least one constraint. If you have Claude Code installed, run them and compare the output to what you expected. Where did the agent surprise you? Where did your prompt need more specificity?
+- Pick a feature you want to build (or use: a reading list with add/remove/mark-as-read).
+- Write three prompts, each building on the last: (1) the data structure and initial component, (2) a specific interaction (adding a book), (3) a visual refinement (styling the list).
+- For each prompt, include context, intent, and at least one constraint.
+- If you have Claude Code installed, run them and compare the output to what you expected.
+- Note where the agent surprised you, and where your prompt needed more specificity.
 :::
 
 :::resources{title="Go Deeper"}

--- a/content/curriculum/02-the-medium/react-basics.md
+++ b/content/curriculum/02-the-medium/react-basics.md
@@ -24,7 +24,7 @@ Components are functions that return what should appear on screen. They take inp
 
 The power of components is composition. You build small, focused components and combine them into larger ones. A Card component contains a Title, an Image, and a Description. A CardGrid component contains many Cards. A Page component contains a Header, a CardGrid, and a Footer. Simple pieces, assembled into complex interfaces.
 
-```
+```jsx
 // A simple React component:
 function Greeting({ name }) {
   return <h1>Hello, {name}!</h1>;
@@ -65,7 +65,7 @@ In React, you manage state with the useState hook. It gives you two things: the 
 
 The core insight: in React, the UI is a function of state. Change the state, and the UI updates automatically. You never manually change what is on screen. You change the data, and React handles the rest.
 
-```
+```jsx
 // State example: a counter
 import { useState } from 'react';
 
@@ -97,7 +97,7 @@ The differences from HTML are small but important: className instead of class (b
 
 JSX is the reason React feels intuitive for designers. If you can read HTML, you can read JSX. The structure is the same, just with JavaScript superpowers embedded in it.
 
-```
+```jsx
 // JSX looks like HTML with JavaScript embedded:
 function BookList({ books }) {
   return (
@@ -123,7 +123,7 @@ function BookList({ books }) {
 
 In a React project, each component typically lives in its own file. The file exports the component, and other files import it. This is separation of concerns at the file level.
 
-A typical structure: src/components/ for reusable components, src/pages/ for page-level components (one per route), src/styles/ for CSS, src/content/ for data. You have seen this structure in the Open Vector codebase.
+A typical structure: `src/components/` for reusable components, `src/pages/` for page-level components (one per route), `src/styles/` for CSS, `src/content/` for data. You have seen this structure in the Open Vector codebase.
 
 The App.jsx file is the root component, and everything else is nested inside it. The router (React Router) decides which page component to show based on the URL. Layout components (headers, sidebars) wrap the page content.
 
@@ -144,7 +144,12 @@ useState calls are state variables. const [isOpen, setIsOpen] = useState(false) 
 Import statements at the top tell you what other components and libraries are being used. import Sidebar from './Sidebar' means this file uses the Sidebar component.
 
 :::exercise{title="Read a Real Component"}
-Open the Open Vector codebase (or any React project) and pick a component file. Read it without running it. Identify: the component name, its props, any state variables, what it renders, and which child components it uses. Write a one-sentence description of what the component does. Now open the app in a browser and find that component on the page. Does what you see match what you read? This reading skill is what lets you direct an AI agent with precision.
+- Open the Open Vector codebase (or any React project) and pick a component file.
+- Read it without running it.
+- Identify: the component name, its props, any state variables, what it renders, and which child components it uses.
+- Write a one-sentence description of what the component does.
+- Now open the app in a browser and find that component on the page. Does what you see match what you read?
+- This reading skill is what lets you direct an AI agent with precision.
 :::
 
 :::resources{title="Go Deeper"}

--- a/content/curriculum/02-the-medium/your-first-ship.md
+++ b/content/curriculum/02-the-medium/your-first-ship.md
@@ -83,7 +83,16 @@ Now iterate. Look at it on your phone. Show it to a friend. Notice what you want
 Add it to your portfolio. Write a post about what you built. Share the URL. The project is not just a learning exercise. It is proof of capability. You can look at a problem, plan a solution, direct an AI to build it, and ship it. That is a skill employers and clients are desperate for.
 
 :::exercise{title="Ship It"}
-Right now. Pick a project from the ideas list (or use your own). Set a timer for three hours. Follow the five-step process: plan (15 min), set up and deploy the empty project (15 min), build with Claude Code (2 hours), polish (20 min), ship and send the URL to someone (10 min). At the end of three hours, whatever state it is in, it ships. Done is better than perfect. Live is better than local. Ship it.
+- Right now. Pick a project from the ideas list (or use your own).
+- Set a timer for three hours.
+- Follow the five-step process:
+  - Plan (15 min).
+  - Set up and deploy the empty project (15 min).
+  - Build with Claude Code (2 hours).
+  - Polish (20 min).
+  - Ship and send the URL to someone (10 min).
+- At the end of three hours, whatever state it is in, it ships.
+- Done is better than perfect. Live is better than local. Ship it.
 :::
 
 :::resources{title="Go Deeper"}

--- a/content/curriculum/03-the-pipeline/ideation.md
+++ b/content/curriculum/03-the-pipeline/ideation.md
@@ -63,7 +63,12 @@ Use AI for volume, then apply your judgment for selection. The AI does not know 
 You can also use AI to stress-test ideas: "What are the three biggest problems with the browser extension approach?" or "How would a user with low technical skills experience this?"
 
 :::exercise{title="Ten Ideas in Ten Minutes"}
-Pick one of the job statements from the previous lesson. Set a timer for ten minutes. Write ten different solutions: no filtering, no judging, just generating. Include at least two that sound ridiculous. When the timer goes off, evaluate each idea on impact (1-5) and feasibility (1-5). Multiply the scores. The top two ideas are your candidates for prototyping.
+- Pick one of the job statements from the previous lesson.
+- Set a timer for ten minutes.
+- Write ten different solutions: no filtering, no judging, just generating.
+- Include at least two that sound ridiculous.
+- When the timer goes off, evaluate each idea on impact (1–5) and feasibility (1–5). Multiply the scores.
+- The top two ideas are your candidates for prototyping.
 :::
 
 :::resources{title="Go Deeper"}

--- a/content/curriculum/03-the-pipeline/investiture.md
+++ b/content/curriculum/03-the-pipeline/investiture.md
@@ -89,10 +89,16 @@ your-project/
 ```
 
 :::exercise{title="Try It"}
-Create a test directory (mkdir investiture-test && cd investiture-test && git init) and run npx investiture init. Watch what it installs. Browse the .claude/skills/ directory and read one of the SKILL.md files. Notice how each skill declares what it reads, what it checks, and what it produces. Open vector/schemas/ and pick a schema. Notice the machine-readable structure. Now open Claude Code in that directory and run /invest-backfill. Watch it survey the (empty) project and generate starter doctrine. Read the VECTOR.md it creates. Ask yourself: if an AI agent read these files, how much would it understand before writing a single line of code? That is the power of a structured scaffold.
+- Create a test directory: `mkdir investiture-test && cd investiture-test && git init`.
+- Run `npx investiture init`. Watch what it installs.
+- Browse the `.claude/skills/` directory and read one of the `SKILL.md` files. Notice how each skill declares what it reads, what it checks, and what it produces.
+- Open `vector/schemas/` and pick a schema. Notice the machine-readable structure.
+- Open Claude Code in that directory and run `/invest-backfill`. Watch it survey the (empty) project and generate starter doctrine.
+- Read the `VECTOR.md` it creates.
+- Ask yourself: if an AI agent read these files, how much would it understand before writing a single line of code? That is the power of a structured scaffold.
 :::
 
-:::resources{title="Links"}
+:::resources{title="Go Deeper"}
 - [Investiture on GitHub](https://github.com/erikaflowers/investiture). npx investiture init, or clone the full scaffold.
 - [Investiture Framework Page](https://zerovector.design/investiture). The Investiture deep dive on Zero Vector.
 - [VECTOR.md Lesson (Level 01)](/learn/curriculum/01-foundation/vector-md). The artifact that gives agents project context.

--- a/content/curriculum/03-the-pipeline/jtbd.md
+++ b/content/curriculum/03-the-pipeline/jtbd.md
@@ -67,7 +67,11 @@ Jobs to Be Done translate beautifully into AI prompts. Instead of "build a save 
 That prompt encodes the situation (found a recipe elsewhere), the motivation (capture it with one click), and the outcome (as instant as a screenshot). The AI now understands not just what to build, but why, and it will make better implementation decisions because of it.
 
 :::exercise{title="Write Five Job Statements"}
-Take the project you have been developing through this pipeline (or pick a product you use daily). Write five job statements in the format: "When [situation], I want to [motivation], so I can [expected outcome]." For each job, label it as primarily functional, emotional, or social. Now rank them: which job is the most frequent? Which is the most underserved? Which one, if solved perfectly, would make users love the product? That top-ranked job is your primary design target.
+- Take the project you have been developing through this pipeline (or pick a product you use daily).
+- Write five job statements in the format: "When [situation], I want to [motivation], so I can [expected outcome]."
+- For each job, label it as primarily functional, emotional, or social.
+- Rank them: which job is the most frequent? Which is the most underserved? Which one, if solved perfectly, would make users love the product?
+- That top-ranked job is your primary design target.
 :::
 
 :::resources{title="Go Deeper"}

--- a/content/curriculum/03-the-pipeline/prototyping.md
+++ b/content/curriculum/03-the-pipeline/prototyping.md
@@ -67,7 +67,13 @@ This is not rushing. This is being disciplined about scope. You are not building
 One day of prototyping and testing teaches you more than two weeks of planning.
 
 :::exercise{title="Build a Prototype"}
-Take the winning idea from the Ideation lesson. Identify the one thing you want to test, the riskiest assumption. Build the minimum prototype that tests it. If you have Claude Code, spend 30 minutes building a working version. If not, sketch six screens on paper showing the key flow. Then show it to one person and ask: "Does this make sense? Would you use this? What is missing?" Write down their answers. You just completed one cycle of prototype-and-test.
+- Take the winning idea from the Ideation lesson.
+- Identify the one thing you want to test — the riskiest assumption.
+- Build the minimum prototype that tests it.
+  - If you have Claude Code, spend 30 minutes building a working version.
+  - If not, sketch six screens on paper showing the key flow.
+- Show it to one person and ask: "Does this make sense? Would you use this? What is missing?"
+- Write down their answers. You just completed one cycle of prototype-and-test.
 :::
 
 :::resources{title="Go Deeper"}

--- a/content/curriculum/03-the-pipeline/research.md
+++ b/content/curriculum/03-the-pipeline/research.md
@@ -61,7 +61,12 @@ Write down: the problem in one sentence, who has it, how they currently deal wit
 This document becomes the foundation of everything that follows: your JTBD statements, your feature decisions, your prompts to AI agents, your eventual marketing copy. Good research compounds.
 
 :::exercise{title="Research a Problem"}
-Pick a problem you want to solve (or a product category you find interesting). Spend 30 minutes on desk research: look at three competing products, read their reviews (especially negative ones), and find one community forum where people discuss the problem. Write down the top five pain points you discovered. Now write three interview questions you would ask a real user. If you can, actually ask someone: a friend, a colleague, a family member who fits the audience. Compare what they say to what you found online.
+- Pick a problem you want to solve (or a product category you find interesting).
+- Spend 30 minutes on desk research: look at three competing products, read their reviews (especially negative ones), and find one community forum where people discuss the problem.
+- Write down the top five pain points you discovered.
+- Write three interview questions you would ask a real user.
+- If you can, actually ask someone: a friend, a colleague, a family member who fits the audience.
+- Compare what they say to what you found online.
 :::
 
 :::resources{title="Go Deeper"}

--- a/content/curriculum/03-the-pipeline/shipping.md
+++ b/content/curriculum/03-the-pipeline/shipping.md
@@ -79,7 +79,15 @@ This is not a waterfall process where each step must complete before the next be
 The pipeline is your superpower. Combined with AI tools, it lets one person do what used to require a team: understand a problem, design a solution, build it, test it, and ship it. That is the Zero Vector promise. And you just practiced it.
 
 :::exercise{title="Ship and Reflect"}
-Take the project you have built through this level (or any project you have been working on). Ship it. Deploy it, share the URL with at least three people, and ask them to use it. Collect feedback for one week. At the end of the week, write a one-page reflection: What did users do that surprised you? What was the most common complaint? What feature request came up more than once? What would you prioritize for version 2? This reflection is the beginning of your next cycle through the pipeline.
+- Take the project you have built through this level (or any project you have been working on).
+- Ship it: deploy it, share the URL with at least three people, and ask them to use it.
+- Collect feedback for one week.
+- At the end of the week, write a one-page reflection answering:
+  - What did users do that surprised you?
+  - What was the most common complaint?
+  - What feature request came up more than once?
+  - What would you prioritize for version 2?
+- This reflection is the beginning of your next cycle through the pipeline.
 :::
 
 :::resources{title="Go Deeper"}

--- a/content/curriculum/03-the-pipeline/synthesis.md
+++ b/content/curriculum/03-the-pipeline/synthesis.md
@@ -65,7 +65,12 @@ Your behavioral profiles inform your prioritization. If most users are "collecto
 Good synthesis makes every downstream decision clearer. If you find yourself stuck on a feature decision later, go back to your insights. The answer is usually there.
 
 :::exercise{title="Synthesize Your Research"}
-Take the research from the previous lesson (or use product reviews from an app you use). Write each distinct observation on a separate line in a document (or physical sticky notes). Group related observations together. Name each group with a theme. Write one insight statement per group, not a summary of what people said, but an interpretation of what it means. You should end up with 3-5 insight statements that tell a coherent story about what your users actually need.
+- Take the research from the previous lesson (or use product reviews from an app you use).
+- Write each distinct observation on a separate line in a document (or physical sticky notes).
+- Group related observations together.
+- Name each group with a theme.
+- Write one insight statement per group — not a summary of what people said, but an interpretation of what it means.
+- Aim for 3–5 insight statements that tell a coherent story about what your users actually need.
 :::
 
 :::resources{title="Go Deeper"}

--- a/content/curriculum/03-the-pipeline/validation.md
+++ b/content/curriculum/03-the-pipeline/validation.md
@@ -71,7 +71,13 @@ Pivot: The core concept does not work. Users could use it but did not want to. T
 The hardest decision is the pivot. You have invested time and emotion. But pivoting with a prototype is cheap. Pivoting with a launched product is expensive. This is exactly why you validate before you ship.
 
 :::exercise{title="Test with Three People"}
-Take your prototype from the previous lesson. Write three tasks that a user should be able to accomplish. Find three people (friends, family, colleagues, anyone who is not you). Give them the tasks one at a time and watch them work. Do not help unless they are truly stuck. After all tasks, ask: "What was the hardest part?" and "Would you use this again?" Write down every problem you observed, ranked by severity. You now have a validated, prioritized list of what to fix next.
+- Take your prototype from the previous lesson.
+- Write three tasks that a user should be able to accomplish.
+- Find three people (friends, family, colleagues — anyone who is not you).
+- Give them the tasks one at a time and watch them work. Do not help unless they are truly stuck.
+- After all tasks, ask: "What was the hardest part?" and "Would you use this again?"
+- Write down every problem you observed, ranked by severity.
+- You now have a validated, prioritized list of what to fix next.
 :::
 
 :::resources{title="Go Deeper"}

--- a/content/curriculum/04-orchestration/claude-md.md
+++ b/content/curriculum/04-orchestration/claude-md.md
@@ -30,7 +30,7 @@ Architecture. How is the project structured? What are the key directories? Where
 
 Rules. What should the agent never do? "Never modify the database schema without asking." "Do not add dependencies without approval." "Never commit directly to main." These guardrails prevent expensive mistakes.
 
-```
+```markdown
 # Project: Recipe Organizer
 
 A web app for saving and organizing recipes from around the web.
@@ -110,7 +110,16 @@ Together, they form the full Zero Vector context stack. VECTOR.md is the project
 This pairing is what separates Zero Vector from ad hoc prompting. Without VECTOR.md, your agent knows the rules but not the reasons. Without CLAUDE.md, your agent knows the vision but not the method. Both documents live at the root of your project, both are read automatically, and both should exist before the first line of code is written.
 
 :::exercise{title="Write Your First CLAUDE.md"}
-Create a CLAUDE.md for a project you are working on (or the practice project from earlier levels). Include: a two-sentence project description, the tech stack, three conventions you follow, a brief architecture map, and at least two rules. Keep it under 50 lines. Then open the project with Claude Code and ask it to describe the project back to you. If it gets it right, your CLAUDE.md works.
+- Create a `CLAUDE.md` for a project you are working on (or the practice project from earlier levels).
+- Include:
+  - A two-sentence project description.
+  - The tech stack.
+  - Three conventions you follow.
+  - A brief architecture map.
+  - At least two rules.
+- Keep it under 50 lines.
+- Open the project with Claude Code and ask it to describe the project back to you.
+- If it gets it right, your `CLAUDE.md` works.
 :::
 
 :::resources{title="Go Deeper"}

--- a/content/curriculum/04-orchestration/multi-agent.md
+++ b/content/curriculum/04-orchestration/multi-agent.md
@@ -36,7 +36,7 @@ This separation is powerful because the same AI that writes code is not great at
 
 The hardest part of multi-agent work is defining boundaries. Which agent owns what? What happens when responsibilities overlap?
 
-Define ownership by files. "Agent A owns everything in src/components/. Agent B owns everything in api/." File-based boundaries are clean. There is no ambiguity about who should modify what.
+Define ownership by files. "Agent A owns everything in `src/components/`. Agent B owns everything in `api/`." File-based boundaries are clean. There is no ambiguity about who should modify what.
 
 Define ownership by capability. "Agent A writes code. Agent B writes tests. Agent C writes documentation." Capability-based boundaries work well when multiple agents need to read the same files but produce different outputs.
 
@@ -73,7 +73,10 @@ Add a second agent for the thing that is most different from your primary work. 
 The ceiling for most individual projects is three to five agents. Beyond that, the coordination overhead exceeds the specialization benefit. Save larger crews for larger projects with clear architectural boundaries.
 
 :::exercise{title="The Builder-Reviewer Split"}
-Open two terminal sessions with Claude Code in the same project. In the first, set the context: "You are the builder. Your job is to create a simple to-do list component with add, complete, and delete functionality." Let it build. Then in the second session, set the context: "You are the reviewer. Read the to-do list component that was just created. List every bug, edge case, accessibility issue, and code quality concern you can find. Do not fix anything, only report." Compare what the reviewer finds to what the builder thought was complete.
+- Open two terminal sessions with Claude Code in the same project.
+- In the first, set the context: "You are the builder. Your job is to create a simple to-do list component with add, complete, and delete functionality." Let it build.
+- In the second session, set the context: "You are the reviewer. Read the to-do list component that was just created. List every bug, edge case, accessibility issue, and code quality concern you can find. Do not fix anything, only report."
+- Compare what the reviewer finds to what the builder thought was complete.
 :::
 
 :::resources{title="Go Deeper"}

--- a/content/curriculum/04-orchestration/orchestration.md
+++ b/content/curriculum/04-orchestration/orchestration.md
@@ -46,9 +46,9 @@ The key to parallel work is contracts. A contract is an agreement between two ag
 
 Before starting parallel work, define the contract explicitly. Write it down in a shared document or a type definition file. Both agents reference this contract. Neither agent deviates from it.
 
-A simple contract for a recipe search feature: "GET /api/recipes/search?q=pasta returns { results: [{ id: string, title: string, matchScore: number }], total: number }." The backend agent builds to this spec. The frontend agent builds against this spec. When both are done, they connect seamlessly.
+A simple contract for a recipe search feature: `GET /api/recipes/search?q=pasta` returns `{ results: [{ id: string, title: string, matchScore: number }], total: number }`. The backend agent builds to this spec. The frontend agent builds against this spec. When both are done, they connect seamlessly.
 
-Without a contract, two agents working in parallel will make different assumptions. The backend returns "items" while the frontend expects "results." The backend returns nested objects while the frontend expects flat ones. These mismatches are expensive to debug.
+Without a contract, two agents working in parallel will make different assumptions. The backend returns `"items"` while the frontend expects `"results"`. The backend returns nested objects while the frontend expects flat ones. These mismatches are expensive to debug.
 
 ## Session Management
 
@@ -87,7 +87,11 @@ Single-session marathons: Running one agent session for eight hours. Context deg
 No contracts: Running parallel agents without agreeing on interfaces first. The integration will be painful.
 
 :::exercise{title="Orchestrate a Two-Agent Build"}
-Pick a small feature with a frontend and backend component (a contact form with a submission endpoint, a search page with search API, etc.). Write the contract first: define the exact API endpoint, request format, and response format. Then give the backend task to one Claude Code session and the frontend task to another. Both sessions get the contract as part of their prompt. Build both sides, then integrate. Note where the contract saved you and where you wish you had specified more.
+- Pick a small feature with a frontend and backend component (a contact form with a submission endpoint, a search page with search API, etc.).
+- Write the contract first: define the exact API endpoint, request format, and response format.
+- Give the backend task to one Claude Code session and the frontend task to another. Both sessions get the contract as part of their prompt.
+- Build both sides, then integrate.
+- Note where the contract saved you and where you wish you had specified more.
 :::
 
 :::resources{title="Go Deeper"}

--- a/content/curriculum/04-orchestration/quality-gates.md
+++ b/content/curriculum/04-orchestration/quality-gates.md
@@ -83,7 +83,16 @@ If code quality is poor: refactor before continuing. Bad code that works is temp
 Git makes recovery safe. You committed after each stage, right? Then reverting is one command. This is why verification and version control work together.
 
 :::exercise{title="Build a Quality Checklist"}
-Create a quality gate checklist for your project. Write five to seven items you will check after every agent task. Include at least one from each category: build (does it compile), functional (does it work), integration (does it play nice), and code quality (can you maintain it). Print it out or pin it next to your screen. Use it for your next five agent sessions. After five sessions, revise it. Which checks caught real issues? Which were unnecessary? Refine the list.
+- Create a quality gate checklist for your project.
+- Write five to seven items you will check after every agent task.
+- Include at least one from each category:
+  - Build (does it compile).
+  - Functional (does it work).
+  - Integration (does it play nice).
+  - Code quality (can you maintain it).
+- Print it out or pin it next to your screen.
+- Use it for your next five agent sessions.
+- After five sessions, revise it. Which checks caught real issues? Which were unnecessary? Refine the list.
 :::
 
 :::resources{title="Go Deeper"}

--- a/content/curriculum/04-orchestration/staged-prompts.md
+++ b/content/curriculum/04-orchestration/staged-prompts.md
@@ -94,7 +94,10 @@ This is not just safety; it is freedom. When you know you can always go back, yo
 The workflow: complete a stage → verify it works → commit with a descriptive message → move to the next stage. Your git log becomes a readable story of how the project was built.
 
 :::exercise{title="Stage a Complex Feature"}
-Think of a feature that feels too complex for a single prompt. A user profile page with avatar upload, editable fields, and password change. A dashboard with charts, filters, and data export. Write it out as three to five staged prompts, each with context, goal, and constraints. Do not build it yet. Just plan the stages. Notice how the complex, intimidating feature becomes a series of manageable steps.
+- Think of a feature that feels too complex for a single prompt — for example, a user profile page with avatar upload, editable fields, and password change; or a dashboard with charts, filters, and data export.
+- Write it out as three to five staged prompts, each with context, goal, and constraints.
+- Do not build it yet. Just plan the stages.
+- Notice how the complex, intimidating feature becomes a series of manageable steps.
 :::
 
 :::resources{title="Go Deeper"}

--- a/content/curriculum/04-orchestration/the-crew-model.md
+++ b/content/curriculum/04-orchestration/the-crew-model.md
@@ -24,7 +24,7 @@ Name and identity. Not for fun, but for clarity. When you say "Heavy handles the
 
 Role description. What does this agent do? "Frontend specialist: owns components, styling, accessibility, and client-side performance." The role is the lens through which the agent makes decisions.
 
-Domain boundaries. What files and systems does this agent own? "Everything in src/components/ and src/styles/. Does not modify API code or database schemas." Boundaries prevent conflicts.
+Domain boundaries. What files and systems does this agent own? "Everything in `src/components/` and `src/styles/`. Does not modify API code or database schemas." Boundaries prevent conflicts.
 
 Communication style. How does this agent talk? Some agents should be terse and technical. Others should be explanatory and thorough. The style should match the domain: a code reviewer should be direct, a documentation writer should be clear.
 
@@ -38,7 +38,7 @@ Each domain is a potential crew member. You do not need all of them immediately.
 
 For a solo builder, a practical starting crew is three agents: a builder (writes features), a reviewer (critiques code), and a planner (designs approaches before building). This trio covers the three modes of work (creation, evaluation, and strategy) that are hardest for one mind to do simultaneously.
 
-```
+```markdown
 # Example: Three-Agent Crew
 
 ## Heavy (Builder)
@@ -108,7 +108,11 @@ You brief the builder again with the reviewer's findings: "Fix these three issue
 Total wall clock time: maybe 45 minutes. The quality is higher than if one agent had done everything because each step was focused and verified.
 
 :::exercise{title="Design Your Crew"}
-Write the CLAUDE.md for a three-agent crew for a project you care about. Define each agent's name, role, domain (specific files and directories), communication style, and coordination rules. Be specific. "Owns the frontend" is too vague. "Owns src/components/, src/hooks/, and src/styles/. Does not modify files in api/ or scripts/" is clear. Then run one work session using at least two of the three agents on a real task. Notice how the separation changes the quality of the output.
+- Write the `CLAUDE.md` for a three-agent crew for a project you care about.
+- Define each agent's name, role, domain (specific files and directories), communication style, and coordination rules.
+- Be specific. "Owns the frontend" is too vague. "Owns `src/components/`, `src/hooks/`, and `src/styles/`. Does not modify files in `api/` or `scripts/`" is clear.
+- Run one work session using at least two of the three agents on a real task.
+- Notice how the separation changes the quality of the output.
 :::
 
 :::resources{title="Go Deeper"}

--- a/content/curriculum/05-auteur/auteur-practice.md
+++ b/content/curriculum/05-auteur/auteur-practice.md
@@ -79,7 +79,13 @@ This is not the end of your learning. It is the end of the curriculum and the be
 Go build something. Make it yours. Ship it. Then build the next thing. That is the auteur practice. That is Zero Vector.
 
 :::exercise{title="Your Auteur Statement"}
-Write a one-page auteur statement. It should answer three questions: What do I build and why does it matter? How do I work, and what is my methodology in three sentences? What is the standard I hold my work to, and what makes me say "this is good enough to ship"? This statement is your north star. Not a resume, not a bio, but a declaration of your practice. Revise it every six months. Watch how it evolves as you do.
+- Write a one-page auteur statement.
+- Answer three questions:
+  - What do I build, and why does it matter?
+  - How do I work, and what is my methodology in three sentences?
+  - What is the standard I hold my work to, and what makes me say "this is good enough to ship"?
+- This statement is your north star — not a resume, not a bio, but a declaration of your practice.
+- Revise it every six months. Watch how it evolves as you do.
 :::
 
 :::resources{title="Go Deeper"}

--- a/content/curriculum/05-auteur/community.md
+++ b/content/curriculum/05-auteur/community.md
@@ -59,7 +59,11 @@ The new value of community is: taste, perspective, accountability, and emotional
 These are irreplaceable by AI. An agent can review your code but cannot tell you whether the project is worth building. A human who understands your goals, your constraints, and your aspirations can.
 
 :::exercise{title="Connect with Three People"}
-Find three people whose work you admire. They can be people you know or people you follow online. Reach out to each one with something specific and genuine: a comment on their work, a question about their process, a compliment on something they built. Not "great work!" but something that shows you actually engaged with what they made. If you do not know anyone yet, find three blog posts or projects you admire and leave a thoughtful comment on each. This is the beginning of your community.
+- Find three people whose work you admire. They can be people you know or people you follow online.
+- Reach out to each one with something specific and genuine: a comment on their work, a question about their process, a compliment on something they built.
+- Not "great work!" but something that shows you actually engaged with what they made.
+- If you do not know anyone yet, find three blog posts or projects you admire and leave a thoughtful comment on each.
+- This is the beginning of your community.
 :::
 
 :::resources{title="Go Deeper"}

--- a/content/curriculum/05-auteur/contribution.md
+++ b/content/curriculum/05-auteur/contribution.md
@@ -61,7 +61,12 @@ Contribute at a rhythm that fits your life. One blog post a month. One documenta
 Set boundaries early. If you open-source a project, decide upfront how much maintenance you are willing to do. A clear README that says "this is a personal project, no guarantees on issue response times" sets expectations and protects your energy.
 
 :::exercise{title="Make Your First Contribution"}
-Choose one: (1) Open-source a project from this curriculum. Push it to GitHub with a README and MIT license. (2) Find a documentation page for a tool you use that confused you. Submit a pull request improving it, even if the improvement is just a clearer example. (3) Find a question on a forum or community channel about something you know and write a thorough answer. Do one of these today. The first contribution is the hardest. Every one after it is easier.
+- Choose one of these three options:
+  - Open-source a project from this curriculum. Push it to GitHub with a README and MIT license.
+  - Find a documentation page for a tool you use that confused you. Submit a pull request improving it, even if the improvement is just a clearer example.
+  - Find a question on a forum or community channel about something you know and write a thorough answer.
+- Do one of these today.
+- The first contribution is the hardest. Every one after it is easier.
 :::
 
 :::resources{title="Go Deeper"}

--- a/content/curriculum/05-auteur/framework-design.md
+++ b/content/curriculum/05-auteur/framework-design.md
@@ -71,7 +71,13 @@ The first user of your framework should not be you. You have too much implicit k
 The second test is time. Use your own framework for a month. The excitement of creation fades. Daily use reveals the friction: the naming that seemed clever is actually confusing, the default that seemed sensible is actually wrong, and the pattern that seemed elegant is actually cumbersome.
 
 :::exercise{title="Extract a Framework"}
-Look at your last three projects. Find one thing you did in all three: a project structure, a naming convention, a way of organizing components, a checklist you followed. Extract it into a reusable template or document. Give it a name. Write a one-paragraph description of what it does and when to use it. Then start your next project using it. Note where it helps and where it needs adjustment.
+- Look at your last three projects.
+- Find one thing you did in all three: a project structure, a naming convention, a way of organizing components, a checklist you followed.
+- Extract it into a reusable template or document.
+- Give it a name.
+- Write a one-paragraph description of what it does and when to use it.
+- Start your next project using it.
+- Note where it helps and where it needs adjustment.
 :::
 
 :::resources{title="Go Deeper"}

--- a/content/curriculum/05-auteur/personal-methodology.md
+++ b/content/curriculum/05-auteur/personal-methodology.md
@@ -73,7 +73,16 @@ The danger is ossification, clinging to a methodology that no longer serves you 
 Schedule time to question your own methodology. What would I change if I started from scratch? What am I doing out of habit? What have I learned recently that should change how I work? The willingness to question your own process is what keeps a methodology alive.
 
 :::exercise{title="Write Your Methodology v1"}
-On one page (or one screen), write your current personal methodology. Include: how you start a project (three steps), how you decide between options (one framework), what "good enough" means (two criteria), what you do when stuck (one pattern), and how you finish (two steps). Keep each point to one sentence. This is version one. Pin it where you can see it. Revisit it after your next three projects and revise.
+- On one page (or one screen), write your current personal methodology.
+- Include:
+  - How you start a project (three steps).
+  - How you decide between options (one framework).
+  - What "good enough" means (two criteria).
+  - What you do when stuck (one pattern).
+  - How you finish (two steps).
+- Keep each point to one sentence.
+- This is version one. Pin it where you can see it.
+- Revisit it after your next three projects and revise.
 :::
 
 :::resources{title="Go Deeper"}

--- a/content/curriculum/05-auteur/teaching.md
+++ b/content/curriculum/05-auteur/teaching.md
@@ -71,7 +71,11 @@ But the leverage goes beyond knowledge transfer. Teaching builds reputation. Peo
 The Zero Vector philosophy says: design is not a solitary pursuit. It is a craft practiced in community. Teaching is how you contribute to that community. You learned from others. Now others learn from you. The cycle continues.
 
 :::exercise{title="Teach One Thing"}
-Pick one concept from this curriculum that you now understand well. Write a 500-word explanation of it, aimed at someone who has never encountered it. Use one analogy, one concrete example, and zero jargon (or define every term you use). Publish it anywhere: on a blog, on social media, in a Slack channel, anywhere someone might read it. Teaching one thing, one time, to one audience is how you start.
+- Pick one concept from this curriculum that you now understand well.
+- Write a 500-word explanation of it, aimed at someone who has never encountered it.
+- Use one analogy, one concrete example, and zero jargon (or define every term you use).
+- Publish it anywhere: on a blog, on social media, in a Slack channel — anywhere someone might read it.
+- Teaching one thing, one time, to one audience is how you start.
 :::
 
 :::resources{title="Go Deeper"}

--- a/docs/curriculum-formatting-audit.md
+++ b/docs/curriculum-formatting-audit.md
@@ -34,7 +34,7 @@ Fixes ship as a **single PR** covering all levels — one commit per file inside
 
 ### 00-orientation
 - [x] **what-is-zero-vector.md** — L87: `:::resources{title="Links"}` → `"Go Deeper"`.
-- [ ] **terminal.md** — L85: bash fence (commands with `#` comments) needs ` ```bash`. L38, L45, L51 stay bare (login banner / shell prompt examples).
+- [x] **terminal.md** — L85: bash fence (commands with `#` comments) needs ` ```bash`. L38, L45, L51 stay bare (login banner / shell prompt examples).
 - [ ] **file-systems.md** — clean. (L43, L60 paths and L95 file tree all stay bare.)
 - [ ] **git-basics.md** — L70: bash fence (`git init` etc.) needs ` ```bash`. L47 stays bare (numbered explanation, not commands).
 - [ ] **repos.md** — L34, L86: bash fences (`git clone`, `git push`) need ` ```bash`.

--- a/docs/curriculum-formatting-audit.md
+++ b/docs/curriculum-formatting-audit.md
@@ -69,7 +69,7 @@ Fixes ship as a **single PR** covering all levels — one commit per file inside
 - [x] **investiture.md** — L95: `:::resources{title="Links"}` → `"Go Deeper"`. L72 file tree stays bare. Bulletize exercise (L91 prose); within bullets, backtick `mkdir investiture-test && cd ... && git init`, `npx investiture init`, `.claude/skills/`, `SKILL.md`, `vector/schemas/`, `/invest-backfill`, `VECTOR.md`.
 
 ### 04-orchestration
-- [ ] **claude-md.md** — L33: markdown sample needs ` ```markdown`. Bulletize exercise (L112 prose).
+- [x] **claude-md.md** — L33: markdown sample needs ` ```markdown`. Bulletize exercise (L112 prose).
 - [ ] **multi-agent.md** — L39 prose: backtick `src/components/`, `api/`. Bulletize exercise (L75 prose).
 - [ ] **staged-prompts.md** — Bulletize exercise (L96 prose). L55 prompt text stays bare.
 - [ ] **orchestration.md** — L48 prose: backtick `GET /api/recipes/search?q=pasta`, the response-shape JSON, and the `"items"` / `"results"` field-name examples. Bulletize exercise (L89 prose).

--- a/docs/curriculum-formatting-audit.md
+++ b/docs/curriculum-formatting-audit.md
@@ -4,11 +4,13 @@ Step 1 of the Open Vector improvement plan — a per-lesson punch list of format
 
 ## Workflow
 
-Fixes are packaged **by level** — one branch and one PR per level, one commit per file inside the branch. This bundles the related changes for issue #14 while preserving per-file commit history. (Default curriculum workflow remains one-file-per-branch; level-packaging is the exception for coordinated multi-file cleanups.)
+Fixes ship as a **single PR** covering all levels — one commit per file inside one branch. The change type is uniform across the curriculum (bulletize exercises, add code-fence hints, add inline code, fix `:::resources` title), so a single review pass against this audit doc is faster for the reviewer than six separate per-level reviews.
 
-- Branch name pattern: `fix-curriculum-fmt-{level-slug}-02may` (e.g. `fix-curriculum-fmt-00-orientation-02may`).
-- Open the PR when every file in that level is committed and its checkbox below is ticked.
-- **Six PRs total: levels 00, 01, 02, 03, 04, 05.**
+- Branch: `fix-curriculum-formatting-02may`.
+- One commit per file (33 commits total), each ticking off its checkbox below.
+- Open one PR when every box is ticked.
+
+(Default curriculum workflow remains one-file-per-branch. This single-PR-for-the-whole-sweep packaging is specific to issue #14 because the changes are uniform and audit-driven.)
 
 ## Canon
 

--- a/docs/curriculum-formatting-audit.md
+++ b/docs/curriculum-formatting-audit.md
@@ -78,7 +78,7 @@ Fixes ship as a **single PR** covering all levels — one commit per file inside
 
 ### 05-auteur
 - [x] **personal-methodology.md** — Bulletize exercise (L75 prose).
-- [ ] **framework-design.md** — Bulletize exercise (L73 prose).
+- [x] **framework-design.md** — Bulletize exercise (L73 prose).
 - [ ] **teaching.md** — Bulletize exercise (L73 prose).
 - [ ] **contribution.md** — Bulletize exercise (L63 prose; convert the inline `(1)/(2)/(3)` options into bullets).
 - [ ] **community.md** — Bulletize exercise (L61 prose).

--- a/docs/curriculum-formatting-audit.md
+++ b/docs/curriculum-formatting-audit.md
@@ -66,7 +66,7 @@ Fixes ship as a **single PR** covering all levels — one commit per file inside
 - [x] **prototyping.md** — Bulletize exercise (L69 prose).
 - [x] **validation.md** — Bulletize exercise (L73 prose).
 - [x] **shipping.md** — Bulletize exercise (L81 prose).
-- [ ] **investiture.md** — L95: `:::resources{title="Links"}` → `"Go Deeper"`. L72 file tree stays bare. Bulletize exercise (L91 prose); within bullets, backtick `mkdir investiture-test && cd ... && git init`, `npx investiture init`, `.claude/skills/`, `SKILL.md`, `vector/schemas/`, `/invest-backfill`, `VECTOR.md`.
+- [x] **investiture.md** — L95: `:::resources{title="Links"}` → `"Go Deeper"`. L72 file tree stays bare. Bulletize exercise (L91 prose); within bullets, backtick `mkdir investiture-test && cd ... && git init`, `npx investiture init`, `.claude/skills/`, `SKILL.md`, `vector/schemas/`, `/invest-backfill`, `VECTOR.md`.
 
 ### 04-orchestration
 - [ ] **claude-md.md** — L33: markdown sample needs ` ```markdown`. Bulletize exercise (L112 prose).

--- a/docs/curriculum-formatting-audit.md
+++ b/docs/curriculum-formatting-audit.md
@@ -71,7 +71,7 @@ Fixes ship as a **single PR** covering all levels — one commit per file inside
 ### 04-orchestration
 - [x] **claude-md.md** — L33: markdown sample needs ` ```markdown`. Bulletize exercise (L112 prose).
 - [x] **multi-agent.md** — L39 prose: backtick `src/components/`, `api/`. Bulletize exercise (L75 prose).
-- [ ] **staged-prompts.md** — Bulletize exercise (L96 prose). L55 prompt text stays bare.
+- [x] **staged-prompts.md** — Bulletize exercise (L96 prose). L55 prompt text stays bare.
 - [ ] **orchestration.md** — L48 prose: backtick `GET /api/recipes/search?q=pasta`, the response-shape JSON, and the `"items"` / `"results"` field-name examples. Bulletize exercise (L89 prose).
 - [ ] **quality-gates.md** — Bulletize exercise (L85 prose).
 - [ ] **the-crew-model.md** — L41: markdown sample needs ` ```markdown`. L27 prose: backtick `src/components/`, `src/styles/`. Bulletize exercise (L110 prose); within bullets, backtick `src/components/`, `src/hooks/`, `src/styles/`, `api/`, `scripts/`.

--- a/docs/curriculum-formatting-audit.md
+++ b/docs/curriculum-formatting-audit.md
@@ -1,0 +1,83 @@
+# Curriculum formatting audit (issue #14)
+
+Step 1 of the Open Vector improvement plan — a per-lesson punch list of formatting deviations from canon. Fixes ship lesson-by-lesson against this checklist on separate branches; tick each box as its branch merges.
+
+## Canon
+
+1. **Frontmatter — required keys (any order):** `slug`, `title`, `subtitle`, `duration`, `status`. Optional, not a deviation if absent: `badge`, `updatedAt`, `knowledgeCheck`. ✅ All 40 files conform.
+2. **Code fences — language hints** when content is identifiably one of `bash`, `javascript`/`js`, `jsx`, `css`, `json`, `yaml`, `markdown`. **Bare fences are correct** for ASCII diagrams, file-tree drawings, terminal prompt examples that aren't commands, freeform output, prompt/dialogue text, and pseudocode outlines.
+3. **`:::resources` directive title:** canon is `"Go Deeper"`. `"Links"` is a deviation.
+4. **Heading hierarchy:** body uses `##` for sections, `###` for subsections. No body H1; the title comes from frontmatter. ✅ All 40 files conform.
+5. **List bullets:** unordered lists use `-` (hyphen). ✅ All 40 files conform.
+6. **Spacing:** single blank line between sections, no triple blank lines. ✅ All 40 files conform.
+
+## Cross-cutting
+
+- **Code fences:** every code block in the curriculum (45 blocks across 20 lessons) uses bare ` ``` `. The fixes per lesson below add language hints only where content is identifiably a language; diagrams, prompts, and pseudocode stay bare.
+- **`:::resources{title="Links"}`:** 3 lessons deviate from "Go Deeper" canon. Listed inline below.
+- **Lessons with no code blocks** are clean by default unless flagged for the resources-title issue.
+
+## Lessons
+
+### 00-orientation
+- [ ] **what-is-zero-vector.md** — L87: `:::resources{title="Links"}` → `"Go Deeper"`.
+- [ ] **terminal.md** — L85: bash fence (commands with `#` comments) needs ` ```bash`. L38, L45, L51 stay bare (login banner / shell prompt examples).
+- [ ] **file-systems.md** — clean. (L43, L60 paths and L95 file tree all stay bare.)
+- [ ] **git-basics.md** — L70: bash fence (`git init` etc.) needs ` ```bash`. L47 stays bare (numbered explanation, not commands).
+- [ ] **repos.md** — L34, L86: bash fences (`git clone`, `git push`) need ` ```bash`.
+- [ ] **deployment.md** — L52: bash fence (`npm run build` + comments) needs ` ```bash`.
+- [ ] **dns.md** — L102: bash fence (`dig`) needs ` ```bash`. L52 stays bare (DNS record examples, not executable).
+
+### 01-foundation
+- [ ] **systems-thinking.md** — clean.
+- [ ] **architecture.md** — clean. (L39 ASCII architecture diagram stays bare.)
+- [ ] **nouns-and-verbs.md** — clean. (L40 text breakdown stays bare.)
+- [ ] **planning.md** — clean. (L49 decomposition outline stays bare.)
+- [ ] **vector-md.md** — L58: markdown sample (a VECTOR.md example) needs ` ```markdown`. L139: `:::resources{title="Links"}` → `"Go Deeper"`.
+- [ ] **data-modeling.md** — L98: JSON example needs ` ```json`. L31 stays bare (schema pseudocode, not strict JSON).
+- [ ] **information-architecture.md** — clean. (L78 URL examples with `#` comments stay bare — illustrative paths, not bash.)
+
+### 02-the-medium
+- [ ] **claude-code.md** — L33, L45: bash fences (`curl ... | bash`, `cd`/`claude`) need ` ```bash`.
+- [ ] **prompting.md** — clean. (L31 weak-vs-better prompt examples stay bare — dialogue, not code.)
+- [ ] **iteration.md** — clean (no code blocks).
+- [ ] **react-basics.md** — L27, L68, L100: JSX examples need ` ```jsx`.
+- [ ] **deploy.md** — L29: bash fence (deploy checklist with `npm run build` etc.) needs ` ```bash`.
+- [ ] **your-first-ship.md** — clean (no code blocks).
+
+### 03-the-pipeline
+- [ ] **research.md** — clean.
+- [ ] **synthesis.md** — clean.
+- [ ] **jtbd.md** — clean.
+- [ ] **ideation.md** — clean.
+- [ ] **prototyping.md** — clean.
+- [ ] **validation.md** — clean.
+- [ ] **shipping.md** — clean.
+- [ ] **investiture.md** — L95: `:::resources{title="Links"}` → `"Go Deeper"`. L72 file tree stays bare.
+
+### 04-orchestration
+- [ ] **claude-md.md** — L33: markdown sample (a CLAUDE.md example) needs ` ```markdown`.
+- [ ] **multi-agent.md** — clean.
+- [ ] **staged-prompts.md** — clean. (L55 prompt text stays bare.)
+- [ ] **orchestration.md** — clean.
+- [ ] **quality-gates.md** — clean.
+- [ ] **the-crew-model.md** — L41: markdown sample (a crew-config example) needs ` ```markdown`.
+
+### 05-auteur
+- [ ] **personal-methodology.md** — clean.
+- [ ] **framework-design.md** — clean.
+- [ ] **teaching.md** — clean.
+- [ ] **contribution.md** — clean.
+- [ ] **community.md** — clean.
+- [ ] **auteur-practice.md** — clean.
+
+## Tally
+
+- **40 lessons audited.**
+- **17 lessons need changes** (16 for code-fence hints + 3 for `:::resources` title; some overlap).
+- **23 lessons clean.**
+- Estimated unique fence-hint additions: ~17 across the 16 affected files.
+
+## Out of scope (per issue #14, Step 1)
+
+Approach guides under `content/approach/`; screenshots (Step 2); prose rewrites; section restructuring; fact-checking.

--- a/docs/curriculum-formatting-audit.md
+++ b/docs/curriculum-formatting-audit.md
@@ -1,6 +1,14 @@
 # Curriculum formatting audit (issue #14)
 
-Step 1 of the Open Vector improvement plan — a per-lesson punch list of formatting deviations from canon. Fixes ship lesson-by-lesson against this checklist on separate branches; tick each box as its branch merges.
+Step 1 of the Open Vector improvement plan — a per-lesson punch list of formatting deviations from canon. Tick each box as its file is fixed.
+
+## Workflow
+
+Fixes are packaged **by level** — one branch and one PR per level, one commit per file inside the branch. This bundles the related changes for issue #14 while preserving per-file commit history. (Default curriculum workflow remains one-file-per-branch; level-packaging is the exception for coordinated multi-file cleanups.)
+
+- Branch name pattern: `fix-curriculum-fmt-{level-slug}-02may` (e.g. `fix-curriculum-fmt-00-orientation-02may`).
+- Open the PR when every file in that level is committed and its checkbox below is ticked.
+- Five PRs total: levels **00, 01, 02, 03, 04**. Level **05** is fully clean — no PR needed.
 
 ## Canon
 

--- a/docs/curriculum-formatting-audit.md
+++ b/docs/curriculum-formatting-audit.md
@@ -36,7 +36,7 @@ Fixes ship as a **single PR** covering all levels — one commit per file inside
 - [x] **what-is-zero-vector.md** — L87: `:::resources{title="Links"}` → `"Go Deeper"`.
 - [x] **terminal.md** — L85: bash fence (commands with `#` comments) needs ` ```bash`. L38, L45, L51 stay bare (login banner / shell prompt examples).
 - [ ] **file-systems.md** — clean. (L43, L60 paths and L95 file tree all stay bare.)
-- [ ] **git-basics.md** — L70: bash fence (`git init` etc.) needs ` ```bash`. L47 stays bare (numbered explanation, not commands).
+- [x] **git-basics.md** — L70: bash fence (`git init` etc.) needs ` ```bash`. L47 stays bare (numbered explanation, not commands).
 - [ ] **repos.md** — L34, L86: bash fences (`git clone`, `git push`) need ` ```bash`.
 - [ ] **deployment.md** — L52: bash fence (`npm run build` + comments) needs ` ```bash`.
 - [ ] **dns.md** — L102: bash fence (`dig`) needs ` ```bash`. L52 stays bare (DNS record examples, not executable).

--- a/docs/curriculum-formatting-audit.md
+++ b/docs/curriculum-formatting-audit.md
@@ -79,7 +79,7 @@ Fixes ship as a **single PR** covering all levels — one commit per file inside
 ### 05-auteur
 - [x] **personal-methodology.md** — Bulletize exercise (L75 prose).
 - [x] **framework-design.md** — Bulletize exercise (L73 prose).
-- [ ] **teaching.md** — Bulletize exercise (L73 prose).
+- [x] **teaching.md** — Bulletize exercise (L73 prose).
 - [ ] **contribution.md** — Bulletize exercise (L63 prose; convert the inline `(1)/(2)/(3)` options into bullets).
 - [ ] **community.md** — Bulletize exercise (L61 prose).
 - [ ] **auteur-practice.md** — Bulletize exercise (L81 prose).

--- a/docs/curriculum-formatting-audit.md
+++ b/docs/curriculum-formatting-audit.md
@@ -37,7 +37,7 @@ Fixes ship as a **single PR** covering all levels — one commit per file inside
 - [x] **terminal.md** — L85: bash fence (commands with `#` comments) needs ` ```bash`. L38, L45, L51 stay bare (login banner / shell prompt examples).
 - [ ] **file-systems.md** — clean. (L43, L60 paths and L95 file tree all stay bare.)
 - [x] **git-basics.md** — L70: bash fence (`git init` etc.) needs ` ```bash`. L47 stays bare (numbered explanation, not commands).
-- [ ] **repos.md** — L34, L86: bash fences (`git clone`, `git push`) need ` ```bash`.
+- [x] **repos.md** — L34, L86: bash fences (`git clone`, `git push`) need ` ```bash`.
 - [ ] **deployment.md** — L52: bash fence (`npm run build` + comments) needs ` ```bash`.
 - [ ] **dns.md** — L102: bash fence (`dig`) needs ` ```bash`. L52 stays bare (DNS record examples, not executable).
 

--- a/docs/curriculum-formatting-audit.md
+++ b/docs/curriculum-formatting-audit.md
@@ -64,7 +64,7 @@ Fixes ship as a **single PR** covering all levels — one commit per file inside
 - [x] **jtbd.md** — Bulletize exercise (L69 prose).
 - [x] **ideation.md** — Bulletize exercise (L65 prose).
 - [x] **prototyping.md** — Bulletize exercise (L69 prose).
-- [ ] **validation.md** — Bulletize exercise (L73 prose).
+- [x] **validation.md** — Bulletize exercise (L73 prose).
 - [ ] **shipping.md** — Bulletize exercise (L81 prose).
 - [ ] **investiture.md** — L95: `:::resources{title="Links"}` → `"Go Deeper"`. L72 file tree stays bare. Bulletize exercise (L91 prose); within bullets, backtick `mkdir investiture-test && cd ... && git init`, `npx investiture init`, `.claude/skills/`, `SKILL.md`, `vector/schemas/`, `/invest-backfill`, `VECTOR.md`.
 

--- a/docs/curriculum-formatting-audit.md
+++ b/docs/curriculum-formatting-audit.md
@@ -74,7 +74,7 @@ Fixes ship as a **single PR** covering all levels — one commit per file inside
 - [x] **staged-prompts.md** — Bulletize exercise (L96 prose). L55 prompt text stays bare.
 - [x] **orchestration.md** — L48 prose: backtick `GET /api/recipes/search?q=pasta`, the response-shape JSON, and the `"items"` / `"results"` field-name examples. Bulletize exercise (L89 prose).
 - [x] **quality-gates.md** — Bulletize exercise (L85 prose).
-- [ ] **the-crew-model.md** — L41: markdown sample needs ` ```markdown`. L27 prose: backtick `src/components/`, `src/styles/`. Bulletize exercise (L110 prose); within bullets, backtick `src/components/`, `src/hooks/`, `src/styles/`, `api/`, `scripts/`.
+- [x] **the-crew-model.md** — L41: markdown sample needs ` ```markdown`. L27 prose: backtick `src/components/`, `src/styles/`. Bulletize exercise (L110 prose); within bullets, backtick `src/components/`, `src/hooks/`, `src/styles/`, `api/`, `scripts/`.
 
 ### 05-auteur
 - [ ] **personal-methodology.md** — Bulletize exercise (L75 prose).

--- a/docs/curriculum-formatting-audit.md
+++ b/docs/curriculum-formatting-audit.md
@@ -60,7 +60,7 @@ Fixes ship as a **single PR** covering all levels — one commit per file inside
 
 ### 03-the-pipeline
 - [x] **research.md** — Bulletize exercise (L63 prose).
-- [ ] **synthesis.md** — Bulletize exercise (L67 prose).
+- [x] **synthesis.md** — Bulletize exercise (L67 prose).
 - [ ] **jtbd.md** — Bulletize exercise (L69 prose).
 - [ ] **ideation.md** — Bulletize exercise (L65 prose).
 - [ ] **prototyping.md** — Bulletize exercise (L69 prose).

--- a/docs/curriculum-formatting-audit.md
+++ b/docs/curriculum-formatting-audit.md
@@ -8,7 +8,7 @@ Fixes are packaged **by level** — one branch and one PR per level, one commit 
 
 - Branch name pattern: `fix-curriculum-fmt-{level-slug}-02may` (e.g. `fix-curriculum-fmt-00-orientation-02may`).
 - Open the PR when every file in that level is committed and its checkbox below is ticked.
-- Five PRs total: levels **00, 01, 02, 03, 04**. Level **05** is fully clean — no PR needed.
+- **Six PRs total: levels 00, 01, 02, 03, 04, 05.**
 
 ## Canon
 
@@ -18,12 +18,15 @@ Fixes are packaged **by level** — one branch and one PR per level, one commit 
 4. **Heading hierarchy:** body uses `##` for sections, `###` for subsections. No body H1; the title comes from frontmatter. ✅ All 40 files conform.
 5. **List bullets:** unordered lists use `-` (hyphen). ✅ All 40 files conform.
 6. **Spacing:** single blank line between sections, no triple blank lines. ✅ All 40 files conform.
+7. **Bulletized exercises:** `:::exercise{title="..."}` content is a bulleted action list (lines starting with `-`), not paragraph prose. Levels 00 and 01 already conform; levels 02–05 are mostly prose and need conversion.
+8. **Inline code in prose:** wrap in single backticks for literal commands (`npm run build`, `git push`), CLI flags (`--version`), file/folder names (`.env`, `dist/`, `CLAUDE.md`), file paths (`/Users/...`, `~/projects`), code identifiers (`useState`, `BookList`), API endpoints/payloads, and environment variable names (`BUTTONDOWN_API_KEY`). **Do not** backtick general concepts ("the database"), product names in prose (React, Git, Vite, Netlify), or capitalized concept names. Apply this rule both in main prose **and** inside the new exercise bullets.
 
 ## Cross-cutting
 
 - **Code fences:** every code block in the curriculum (45 blocks across 20 lessons) uses bare ` ``` `. The fixes per lesson below add language hints only where content is identifiably a language; diagrams, prompts, and pseudocode stay bare.
 - **`:::resources{title="Links"}`:** 3 lessons deviate from "Go Deeper" canon. Listed inline below.
-- **Lessons with no code blocks** are clean by default unless flagged for the resources-title issue.
+- **Bulletized exercises:** 25 of the 26 exercises in levels 02–05 are paragraph prose. The lone exception is `02-the-medium/claude-code.md`. Levels 00 and 01 are already done. The fix per lesson is the same shape: convert the prose paragraph(s) inside `:::exercise` into a bulleted action list, matching the canon set in `01-foundation/architecture.md`.
+- **Inline code in prose:** levels 00–01 already done. In 02–05, most files are clean but a handful have specific gaps in main prose; flagged inline below. When bulletizing exercises, also apply inline-code formatting to literal commands, paths, and identifiers within the new bullets — these are not flagged exhaustively below since they fall out naturally from the bulletization pass.
 
 ## Lessons
 
@@ -46,45 +49,46 @@ Fixes are packaged **by level** — one branch and one PR per level, one commit 
 - [ ] **information-architecture.md** — clean. (L78 URL examples with `#` comments stay bare — illustrative paths, not bash.)
 
 ### 02-the-medium
-- [ ] **claude-code.md** — L33, L45: bash fences (`curl ... | bash`, `cd`/`claude`) need ` ```bash`.
-- [ ] **prompting.md** — clean. (L31 weak-vs-better prompt examples stay bare — dialogue, not code.)
-- [ ] **iteration.md** — clean (no code blocks).
-- [ ] **react-basics.md** — L27, L68, L100: JSX examples need ` ```jsx`.
-- [ ] **deploy.md** — L29: bash fence (deploy checklist with `npm run build` etc.) needs ` ```bash`.
-- [ ] **your-first-ship.md** — clean (no code blocks).
+- [ ] **claude-code.md** — L33, L45: bash fences (`curl ... | bash`, `cd`/`claude`) need ` ```bash`. Exercise already bulletized ✓.
+- [ ] **prompting.md** — Bulletize exercise (L92 prose). L31 prompt examples stay bare.
+- [ ] **iteration.md** — Bulletize exercise (L75 prose; convert the inline `(1)…(5)` steps into bullets).
+- [ ] **react-basics.md** — L27, L68, L100: JSX examples need ` ```jsx`. L126 prose: backtick `src/components/`, `src/pages/`, `src/styles/`, `src/content/`. Bulletize exercise (L146 prose).
+- [ ] **deploy.md** — L29: bash fence needs ` ```bash`. Bulletize exercise (L96 prose); within bullets, backtick `npm create vite@latest...`, `npm run build`, `dist`, etc.
+- [ ] **your-first-ship.md** — Bulletize exercise (L85 prose; convert the inline numbered five-step process into bullets).
 
 ### 03-the-pipeline
-- [ ] **research.md** — clean.
-- [ ] **synthesis.md** — clean.
-- [ ] **jtbd.md** — clean.
-- [ ] **ideation.md** — clean.
-- [ ] **prototyping.md** — clean.
-- [ ] **validation.md** — clean.
-- [ ] **shipping.md** — clean.
-- [ ] **investiture.md** — L95: `:::resources{title="Links"}` → `"Go Deeper"`. L72 file tree stays bare.
+- [ ] **research.md** — Bulletize exercise (L63 prose).
+- [ ] **synthesis.md** — Bulletize exercise (L67 prose).
+- [ ] **jtbd.md** — Bulletize exercise (L69 prose).
+- [ ] **ideation.md** — Bulletize exercise (L65 prose).
+- [ ] **prototyping.md** — Bulletize exercise (L69 prose).
+- [ ] **validation.md** — Bulletize exercise (L73 prose).
+- [ ] **shipping.md** — Bulletize exercise (L81 prose).
+- [ ] **investiture.md** — L95: `:::resources{title="Links"}` → `"Go Deeper"`. L72 file tree stays bare. Bulletize exercise (L91 prose); within bullets, backtick `mkdir investiture-test && cd ... && git init`, `npx investiture init`, `.claude/skills/`, `SKILL.md`, `vector/schemas/`, `/invest-backfill`, `VECTOR.md`.
 
 ### 04-orchestration
-- [ ] **claude-md.md** — L33: markdown sample (a CLAUDE.md example) needs ` ```markdown`.
-- [ ] **multi-agent.md** — clean.
-- [ ] **staged-prompts.md** — clean. (L55 prompt text stays bare.)
-- [ ] **orchestration.md** — clean.
-- [ ] **quality-gates.md** — clean.
-- [ ] **the-crew-model.md** — L41: markdown sample (a crew-config example) needs ` ```markdown`.
+- [ ] **claude-md.md** — L33: markdown sample needs ` ```markdown`. Bulletize exercise (L112 prose).
+- [ ] **multi-agent.md** — L39 prose: backtick `src/components/`, `api/`. Bulletize exercise (L75 prose).
+- [ ] **staged-prompts.md** — Bulletize exercise (L96 prose). L55 prompt text stays bare.
+- [ ] **orchestration.md** — L48 prose: backtick `GET /api/recipes/search?q=pasta`, the response-shape JSON, and the `"items"` / `"results"` field-name examples. Bulletize exercise (L89 prose).
+- [ ] **quality-gates.md** — Bulletize exercise (L85 prose).
+- [ ] **the-crew-model.md** — L41: markdown sample needs ` ```markdown`. L27 prose: backtick `src/components/`, `src/styles/`. Bulletize exercise (L110 prose); within bullets, backtick `src/components/`, `src/hooks/`, `src/styles/`, `api/`, `scripts/`.
 
 ### 05-auteur
-- [ ] **personal-methodology.md** — clean.
-- [ ] **framework-design.md** — clean.
-- [ ] **teaching.md** — clean.
-- [ ] **contribution.md** — clean.
-- [ ] **community.md** — clean.
-- [ ] **auteur-practice.md** — clean.
+- [ ] **personal-methodology.md** — Bulletize exercise (L75 prose).
+- [ ] **framework-design.md** — Bulletize exercise (L73 prose).
+- [ ] **teaching.md** — Bulletize exercise (L73 prose).
+- [ ] **contribution.md** — Bulletize exercise (L63 prose; convert the inline `(1)/(2)/(3)` options into bullets).
+- [ ] **community.md** — Bulletize exercise (L61 prose).
+- [ ] **auteur-practice.md** — Bulletize exercise (L81 prose).
 
 ## Tally
 
 - **40 lessons audited.**
-- **17 lessons need changes** (16 for code-fence hints + 3 for `:::resources` title; some overlap).
-- **23 lessons clean.**
-- Estimated unique fence-hint additions: ~17 across the 16 affected files.
+- **33 lessons need changes** across all 6 levels.
+- **7 lessons clean** (all in 00-orientation and 01-foundation).
+- Levels 00 and 01: code-fence hints + 3 `:::resources` title fixes only (already inline-coded and bulletized).
+- Levels 02–05: 25 of 26 exercises need bulletizing; plus code-fence hints, the third `:::resources` fix, and a handful of inline-code gaps in main prose.
 
 ## Out of scope (per issue #14, Step 1)
 

--- a/docs/curriculum-formatting-audit.md
+++ b/docs/curriculum-formatting-audit.md
@@ -73,7 +73,7 @@ Fixes ship as a **single PR** covering all levels — one commit per file inside
 - [x] **multi-agent.md** — L39 prose: backtick `src/components/`, `api/`. Bulletize exercise (L75 prose).
 - [x] **staged-prompts.md** — Bulletize exercise (L96 prose). L55 prompt text stays bare.
 - [x] **orchestration.md** — L48 prose: backtick `GET /api/recipes/search?q=pasta`, the response-shape JSON, and the `"items"` / `"results"` field-name examples. Bulletize exercise (L89 prose).
-- [ ] **quality-gates.md** — Bulletize exercise (L85 prose).
+- [x] **quality-gates.md** — Bulletize exercise (L85 prose).
 - [ ] **the-crew-model.md** — L41: markdown sample needs ` ```markdown`. L27 prose: backtick `src/components/`, `src/styles/`. Bulletize exercise (L110 prose); within bullets, backtick `src/components/`, `src/hooks/`, `src/styles/`, `api/`, `scripts/`.
 
 ### 05-auteur

--- a/docs/curriculum-formatting-audit.md
+++ b/docs/curriculum-formatting-audit.md
@@ -56,7 +56,7 @@ Fixes ship as a **single PR** covering all levels — one commit per file inside
 - [x] **iteration.md** — Bulletize exercise (L75 prose; convert the inline `(1)…(5)` steps into bullets).
 - [x] **react-basics.md** — L27, L68, L100: JSX examples need ` ```jsx`. L126 prose: backtick `src/components/`, `src/pages/`, `src/styles/`, `src/content/`. Bulletize exercise (L146 prose).
 - [x] **deploy.md** — L29: bash fence needs ` ```bash`. Bulletize exercise (L96 prose); within bullets, backtick `npm create vite@latest...`, `npm run build`, `dist`, etc.
-- [ ] **your-first-ship.md** — Bulletize exercise (L85 prose; convert the inline numbered five-step process into bullets).
+- [x] **your-first-ship.md** — Bulletize exercise (L85 prose; convert the inline numbered five-step process into bullets).
 
 ### 03-the-pipeline
 - [ ] **research.md** — Bulletize exercise (L63 prose).

--- a/docs/curriculum-formatting-audit.md
+++ b/docs/curriculum-formatting-audit.md
@@ -70,7 +70,7 @@ Fixes ship as a **single PR** covering all levels — one commit per file inside
 
 ### 04-orchestration
 - [x] **claude-md.md** — L33: markdown sample needs ` ```markdown`. Bulletize exercise (L112 prose).
-- [ ] **multi-agent.md** — L39 prose: backtick `src/components/`, `api/`. Bulletize exercise (L75 prose).
+- [x] **multi-agent.md** — L39 prose: backtick `src/components/`, `api/`. Bulletize exercise (L75 prose).
 - [ ] **staged-prompts.md** — Bulletize exercise (L96 prose). L55 prompt text stays bare.
 - [ ] **orchestration.md** — L48 prose: backtick `GET /api/recipes/search?q=pasta`, the response-shape JSON, and the `"items"` / `"results"` field-name examples. Bulletize exercise (L89 prose).
 - [ ] **quality-gates.md** — Bulletize exercise (L85 prose).

--- a/docs/curriculum-formatting-audit.md
+++ b/docs/curriculum-formatting-audit.md
@@ -72,7 +72,7 @@ Fixes ship as a **single PR** covering all levels — one commit per file inside
 - [x] **claude-md.md** — L33: markdown sample needs ` ```markdown`. Bulletize exercise (L112 prose).
 - [x] **multi-agent.md** — L39 prose: backtick `src/components/`, `api/`. Bulletize exercise (L75 prose).
 - [x] **staged-prompts.md** — Bulletize exercise (L96 prose). L55 prompt text stays bare.
-- [ ] **orchestration.md** — L48 prose: backtick `GET /api/recipes/search?q=pasta`, the response-shape JSON, and the `"items"` / `"results"` field-name examples. Bulletize exercise (L89 prose).
+- [x] **orchestration.md** — L48 prose: backtick `GET /api/recipes/search?q=pasta`, the response-shape JSON, and the `"items"` / `"results"` field-name examples. Bulletize exercise (L89 prose).
 - [ ] **quality-gates.md** — Bulletize exercise (L85 prose).
 - [ ] **the-crew-model.md** — L41: markdown sample needs ` ```markdown`. L27 prose: backtick `src/components/`, `src/styles/`. Bulletize exercise (L110 prose); within bullets, backtick `src/components/`, `src/hooks/`, `src/styles/`, `api/`, `scripts/`.
 

--- a/docs/curriculum-formatting-audit.md
+++ b/docs/curriculum-formatting-audit.md
@@ -55,7 +55,7 @@ Fixes ship as a **single PR** covering all levels — one commit per file inside
 - [x] **prompting.md** — Bulletize exercise (L92 prose). L31 prompt examples stay bare.
 - [x] **iteration.md** — Bulletize exercise (L75 prose; convert the inline `(1)…(5)` steps into bullets).
 - [x] **react-basics.md** — L27, L68, L100: JSX examples need ` ```jsx`. L126 prose: backtick `src/components/`, `src/pages/`, `src/styles/`, `src/content/`. Bulletize exercise (L146 prose).
-- [ ] **deploy.md** — L29: bash fence needs ` ```bash`. Bulletize exercise (L96 prose); within bullets, backtick `npm create vite@latest...`, `npm run build`, `dist`, etc.
+- [x] **deploy.md** — L29: bash fence needs ` ```bash`. Bulletize exercise (L96 prose); within bullets, backtick `npm create vite@latest...`, `npm run build`, `dist`, etc.
 - [ ] **your-first-ship.md** — Bulletize exercise (L85 prose; convert the inline numbered five-step process into bullets).
 
 ### 03-the-pipeline

--- a/docs/curriculum-formatting-audit.md
+++ b/docs/curriculum-formatting-audit.md
@@ -53,7 +53,7 @@ Fixes ship as a **single PR** covering all levels — one commit per file inside
 ### 02-the-medium
 - [x] **claude-code.md** — L33, L45: bash fences (`curl ... | bash`, `cd`/`claude`) need ` ```bash`. Exercise already bulletized ✓.
 - [x] **prompting.md** — Bulletize exercise (L92 prose). L31 prompt examples stay bare.
-- [ ] **iteration.md** — Bulletize exercise (L75 prose; convert the inline `(1)…(5)` steps into bullets).
+- [x] **iteration.md** — Bulletize exercise (L75 prose; convert the inline `(1)…(5)` steps into bullets).
 - [ ] **react-basics.md** — L27, L68, L100: JSX examples need ` ```jsx`. L126 prose: backtick `src/components/`, `src/pages/`, `src/styles/`, `src/content/`. Bulletize exercise (L146 prose).
 - [ ] **deploy.md** — L29: bash fence needs ` ```bash`. Bulletize exercise (L96 prose); within bullets, backtick `npm create vite@latest...`, `npm run build`, `dist`, etc.
 - [ ] **your-first-ship.md** — Bulletize exercise (L85 prose; convert the inline numbered five-step process into bullets).

--- a/docs/curriculum-formatting-audit.md
+++ b/docs/curriculum-formatting-audit.md
@@ -59,7 +59,7 @@ Fixes ship as a **single PR** covering all levels — one commit per file inside
 - [x] **your-first-ship.md** — Bulletize exercise (L85 prose; convert the inline numbered five-step process into bullets).
 
 ### 03-the-pipeline
-- [ ] **research.md** — Bulletize exercise (L63 prose).
+- [x] **research.md** — Bulletize exercise (L63 prose).
 - [ ] **synthesis.md** — Bulletize exercise (L67 prose).
 - [ ] **jtbd.md** — Bulletize exercise (L69 prose).
 - [ ] **ideation.md** — Bulletize exercise (L65 prose).

--- a/docs/curriculum-formatting-audit.md
+++ b/docs/curriculum-formatting-audit.md
@@ -46,7 +46,7 @@ Fixes ship as a **single PR** covering all levels — one commit per file inside
 - [ ] **architecture.md** — clean. (L39 ASCII architecture diagram stays bare.)
 - [ ] **nouns-and-verbs.md** — clean. (L40 text breakdown stays bare.)
 - [ ] **planning.md** — clean. (L49 decomposition outline stays bare.)
-- [ ] **vector-md.md** — L58: markdown sample (a VECTOR.md example) needs ` ```markdown`. L139: `:::resources{title="Links"}` → `"Go Deeper"`.
+- [x] **vector-md.md** — L58: markdown sample (a VECTOR.md example) needs ` ```markdown`. L139: `:::resources{title="Links"}` → `"Go Deeper"`.
 - [ ] **data-modeling.md** — L98: JSON example needs ` ```json`. L31 stays bare (schema pseudocode, not strict JSON).
 - [ ] **information-architecture.md** — clean. (L78 URL examples with `#` comments stay bare — illustrative paths, not bash.)
 

--- a/docs/curriculum-formatting-audit.md
+++ b/docs/curriculum-formatting-audit.md
@@ -62,7 +62,7 @@ Fixes ship as a **single PR** covering all levels — one commit per file inside
 - [x] **research.md** — Bulletize exercise (L63 prose).
 - [x] **synthesis.md** — Bulletize exercise (L67 prose).
 - [x] **jtbd.md** — Bulletize exercise (L69 prose).
-- [ ] **ideation.md** — Bulletize exercise (L65 prose).
+- [x] **ideation.md** — Bulletize exercise (L65 prose).
 - [ ] **prototyping.md** — Bulletize exercise (L69 prose).
 - [ ] **validation.md** — Bulletize exercise (L73 prose).
 - [ ] **shipping.md** — Bulletize exercise (L81 prose).

--- a/docs/curriculum-formatting-audit.md
+++ b/docs/curriculum-formatting-audit.md
@@ -52,7 +52,7 @@ Fixes ship as a **single PR** covering all levels — one commit per file inside
 
 ### 02-the-medium
 - [x] **claude-code.md** — L33, L45: bash fences (`curl ... | bash`, `cd`/`claude`) need ` ```bash`. Exercise already bulletized ✓.
-- [ ] **prompting.md** — Bulletize exercise (L92 prose). L31 prompt examples stay bare.
+- [x] **prompting.md** — Bulletize exercise (L92 prose). L31 prompt examples stay bare.
 - [ ] **iteration.md** — Bulletize exercise (L75 prose; convert the inline `(1)…(5)` steps into bullets).
 - [ ] **react-basics.md** — L27, L68, L100: JSX examples need ` ```jsx`. L126 prose: backtick `src/components/`, `src/pages/`, `src/styles/`, `src/content/`. Bulletize exercise (L146 prose).
 - [ ] **deploy.md** — L29: bash fence needs ` ```bash`. Bulletize exercise (L96 prose); within bullets, backtick `npm create vite@latest...`, `npm run build`, `dist`, etc.

--- a/docs/curriculum-formatting-audit.md
+++ b/docs/curriculum-formatting-audit.md
@@ -38,7 +38,7 @@ Fixes ship as a **single PR** covering all levels — one commit per file inside
 - [ ] **file-systems.md** — clean. (L43, L60 paths and L95 file tree all stay bare.)
 - [x] **git-basics.md** — L70: bash fence (`git init` etc.) needs ` ```bash`. L47 stays bare (numbered explanation, not commands).
 - [x] **repos.md** — L34, L86: bash fences (`git clone`, `git push`) need ` ```bash`.
-- [ ] **deployment.md** — L52: bash fence (`npm run build` + comments) needs ` ```bash`.
+- [x] **deployment.md** — L52: bash fence (`npm run build` + comments) needs ` ```bash`.
 - [ ] **dns.md** — L102: bash fence (`dig`) needs ` ```bash`. L52 stays bare (DNS record examples, not executable).
 
 ### 01-foundation

--- a/docs/curriculum-formatting-audit.md
+++ b/docs/curriculum-formatting-audit.md
@@ -33,7 +33,7 @@ Fixes ship as a **single PR** covering all levels — one commit per file inside
 ## Lessons
 
 ### 00-orientation
-- [ ] **what-is-zero-vector.md** — L87: `:::resources{title="Links"}` → `"Go Deeper"`.
+- [x] **what-is-zero-vector.md** — L87: `:::resources{title="Links"}` → `"Go Deeper"`.
 - [ ] **terminal.md** — L85: bash fence (commands with `#` comments) needs ` ```bash`. L38, L45, L51 stay bare (login banner / shell prompt examples).
 - [ ] **file-systems.md** — clean. (L43, L60 paths and L95 file tree all stay bare.)
 - [ ] **git-basics.md** — L70: bash fence (`git init` etc.) needs ` ```bash`. L47 stays bare (numbered explanation, not commands).

--- a/docs/curriculum-formatting-audit.md
+++ b/docs/curriculum-formatting-audit.md
@@ -63,7 +63,7 @@ Fixes ship as a **single PR** covering all levels — one commit per file inside
 - [x] **synthesis.md** — Bulletize exercise (L67 prose).
 - [x] **jtbd.md** — Bulletize exercise (L69 prose).
 - [x] **ideation.md** — Bulletize exercise (L65 prose).
-- [ ] **prototyping.md** — Bulletize exercise (L69 prose).
+- [x] **prototyping.md** — Bulletize exercise (L69 prose).
 - [ ] **validation.md** — Bulletize exercise (L73 prose).
 - [ ] **shipping.md** — Bulletize exercise (L81 prose).
 - [ ] **investiture.md** — L95: `:::resources{title="Links"}` → `"Go Deeper"`. L72 file tree stays bare. Bulletize exercise (L91 prose); within bullets, backtick `mkdir investiture-test && cd ... && git init`, `npx investiture init`, `.claude/skills/`, `SKILL.md`, `vector/schemas/`, `/invest-backfill`, `VECTOR.md`.

--- a/docs/curriculum-formatting-audit.md
+++ b/docs/curriculum-formatting-audit.md
@@ -82,7 +82,7 @@ Fixes ship as a **single PR** covering all levels — one commit per file inside
 - [x] **teaching.md** — Bulletize exercise (L73 prose).
 - [x] **contribution.md** — Bulletize exercise (L63 prose; convert the inline `(1)/(2)/(3)` options into bullets).
 - [x] **community.md** — Bulletize exercise (L61 prose).
-- [ ] **auteur-practice.md** — Bulletize exercise (L81 prose).
+- [x] **auteur-practice.md** — Bulletize exercise (L81 prose).
 
 ## Tally
 

--- a/docs/curriculum-formatting-audit.md
+++ b/docs/curriculum-formatting-audit.md
@@ -54,7 +54,7 @@ Fixes ship as a **single PR** covering all levels — one commit per file inside
 - [x] **claude-code.md** — L33, L45: bash fences (`curl ... | bash`, `cd`/`claude`) need ` ```bash`. Exercise already bulletized ✓.
 - [x] **prompting.md** — Bulletize exercise (L92 prose). L31 prompt examples stay bare.
 - [x] **iteration.md** — Bulletize exercise (L75 prose; convert the inline `(1)…(5)` steps into bullets).
-- [ ] **react-basics.md** — L27, L68, L100: JSX examples need ` ```jsx`. L126 prose: backtick `src/components/`, `src/pages/`, `src/styles/`, `src/content/`. Bulletize exercise (L146 prose).
+- [x] **react-basics.md** — L27, L68, L100: JSX examples need ` ```jsx`. L126 prose: backtick `src/components/`, `src/pages/`, `src/styles/`, `src/content/`. Bulletize exercise (L146 prose).
 - [ ] **deploy.md** — L29: bash fence needs ` ```bash`. Bulletize exercise (L96 prose); within bullets, backtick `npm create vite@latest...`, `npm run build`, `dist`, etc.
 - [ ] **your-first-ship.md** — Bulletize exercise (L85 prose; convert the inline numbered five-step process into bullets).
 

--- a/docs/curriculum-formatting-audit.md
+++ b/docs/curriculum-formatting-audit.md
@@ -61,7 +61,7 @@ Fixes ship as a **single PR** covering all levels — one commit per file inside
 ### 03-the-pipeline
 - [x] **research.md** — Bulletize exercise (L63 prose).
 - [x] **synthesis.md** — Bulletize exercise (L67 prose).
-- [ ] **jtbd.md** — Bulletize exercise (L69 prose).
+- [x] **jtbd.md** — Bulletize exercise (L69 prose).
 - [ ] **ideation.md** — Bulletize exercise (L65 prose).
 - [ ] **prototyping.md** — Bulletize exercise (L69 prose).
 - [ ] **validation.md** — Bulletize exercise (L73 prose).

--- a/docs/curriculum-formatting-audit.md
+++ b/docs/curriculum-formatting-audit.md
@@ -51,7 +51,7 @@ Fixes ship as a **single PR** covering all levels — one commit per file inside
 - [ ] **information-architecture.md** — clean. (L78 URL examples with `#` comments stay bare — illustrative paths, not bash.)
 
 ### 02-the-medium
-- [ ] **claude-code.md** — L33, L45: bash fences (`curl ... | bash`, `cd`/`claude`) need ` ```bash`. Exercise already bulletized ✓.
+- [x] **claude-code.md** — L33, L45: bash fences (`curl ... | bash`, `cd`/`claude`) need ` ```bash`. Exercise already bulletized ✓.
 - [ ] **prompting.md** — Bulletize exercise (L92 prose). L31 prompt examples stay bare.
 - [ ] **iteration.md** — Bulletize exercise (L75 prose; convert the inline `(1)…(5)` steps into bullets).
 - [ ] **react-basics.md** — L27, L68, L100: JSX examples need ` ```jsx`. L126 prose: backtick `src/components/`, `src/pages/`, `src/styles/`, `src/content/`. Bulletize exercise (L146 prose).

--- a/docs/curriculum-formatting-audit.md
+++ b/docs/curriculum-formatting-audit.md
@@ -65,7 +65,7 @@ Fixes ship as a **single PR** covering all levels — one commit per file inside
 - [x] **ideation.md** — Bulletize exercise (L65 prose).
 - [x] **prototyping.md** — Bulletize exercise (L69 prose).
 - [x] **validation.md** — Bulletize exercise (L73 prose).
-- [ ] **shipping.md** — Bulletize exercise (L81 prose).
+- [x] **shipping.md** — Bulletize exercise (L81 prose).
 - [ ] **investiture.md** — L95: `:::resources{title="Links"}` → `"Go Deeper"`. L72 file tree stays bare. Bulletize exercise (L91 prose); within bullets, backtick `mkdir investiture-test && cd ... && git init`, `npx investiture init`, `.claude/skills/`, `SKILL.md`, `vector/schemas/`, `/invest-backfill`, `VECTOR.md`.
 
 ### 04-orchestration

--- a/docs/curriculum-formatting-audit.md
+++ b/docs/curriculum-formatting-audit.md
@@ -80,7 +80,7 @@ Fixes ship as a **single PR** covering all levels — one commit per file inside
 - [x] **personal-methodology.md** — Bulletize exercise (L75 prose).
 - [x] **framework-design.md** — Bulletize exercise (L73 prose).
 - [x] **teaching.md** — Bulletize exercise (L73 prose).
-- [ ] **contribution.md** — Bulletize exercise (L63 prose; convert the inline `(1)/(2)/(3)` options into bullets).
+- [x] **contribution.md** — Bulletize exercise (L63 prose; convert the inline `(1)/(2)/(3)` options into bullets).
 - [ ] **community.md** — Bulletize exercise (L61 prose).
 - [ ] **auteur-practice.md** — Bulletize exercise (L81 prose).
 

--- a/docs/curriculum-formatting-audit.md
+++ b/docs/curriculum-formatting-audit.md
@@ -81,7 +81,7 @@ Fixes ship as a **single PR** covering all levels — one commit per file inside
 - [x] **framework-design.md** — Bulletize exercise (L73 prose).
 - [x] **teaching.md** — Bulletize exercise (L73 prose).
 - [x] **contribution.md** — Bulletize exercise (L63 prose; convert the inline `(1)/(2)/(3)` options into bullets).
-- [ ] **community.md** — Bulletize exercise (L61 prose).
+- [x] **community.md** — Bulletize exercise (L61 prose).
 - [ ] **auteur-practice.md** — Bulletize exercise (L81 prose).
 
 ## Tally

--- a/docs/curriculum-formatting-audit.md
+++ b/docs/curriculum-formatting-audit.md
@@ -77,7 +77,7 @@ Fixes ship as a **single PR** covering all levels — one commit per file inside
 - [x] **the-crew-model.md** — L41: markdown sample needs ` ```markdown`. L27 prose: backtick `src/components/`, `src/styles/`. Bulletize exercise (L110 prose); within bullets, backtick `src/components/`, `src/hooks/`, `src/styles/`, `api/`, `scripts/`.
 
 ### 05-auteur
-- [ ] **personal-methodology.md** — Bulletize exercise (L75 prose).
+- [x] **personal-methodology.md** — Bulletize exercise (L75 prose).
 - [ ] **framework-design.md** — Bulletize exercise (L73 prose).
 - [ ] **teaching.md** — Bulletize exercise (L73 prose).
 - [ ] **contribution.md** — Bulletize exercise (L63 prose; convert the inline `(1)/(2)/(3)` options into bullets).

--- a/docs/curriculum-formatting-audit.md
+++ b/docs/curriculum-formatting-audit.md
@@ -47,7 +47,7 @@ Fixes ship as a **single PR** covering all levels — one commit per file inside
 - [ ] **nouns-and-verbs.md** — clean. (L40 text breakdown stays bare.)
 - [ ] **planning.md** — clean. (L49 decomposition outline stays bare.)
 - [x] **vector-md.md** — L58: markdown sample (a VECTOR.md example) needs ` ```markdown`. L139: `:::resources{title="Links"}` → `"Go Deeper"`.
-- [ ] **data-modeling.md** — L98: JSON example needs ` ```json`. L31 stays bare (schema pseudocode, not strict JSON).
+- [x] **data-modeling.md** — L98: JSON example needs ` ```json`. L31 stays bare (schema pseudocode, not strict JSON).
 - [ ] **information-architecture.md** — clean. (L78 URL examples with `#` comments stay bare — illustrative paths, not bash.)
 
 ### 02-the-medium

--- a/docs/curriculum-formatting-audit.md
+++ b/docs/curriculum-formatting-audit.md
@@ -39,7 +39,7 @@ Fixes ship as a **single PR** covering all levels — one commit per file inside
 - [x] **git-basics.md** — L70: bash fence (`git init` etc.) needs ` ```bash`. L47 stays bare (numbered explanation, not commands).
 - [x] **repos.md** — L34, L86: bash fences (`git clone`, `git push`) need ` ```bash`.
 - [x] **deployment.md** — L52: bash fence (`npm run build` + comments) needs ` ```bash`.
-- [ ] **dns.md** — L102: bash fence (`dig`) needs ` ```bash`. L52 stays bare (DNS record examples, not executable).
+- [x] **dns.md** — L102: bash fence (`dig`) needs ` ```bash`. L52 stays bare (DNS record examples, not executable).
 
 ### 01-foundation
 - [ ] **systems-thinking.md** — clean.


### PR DESCRIPTION
## Summary

Implements the curriculum formatting audit defined in `docs/curriculum-formatting-audit.md` for issue #14, and consolidates the six open level-01 bulletization PRs (#37–#42) into a single shippable change so the audit's claim that "levels 00 and 01 already conform" becomes true at merge time rather than depending on a six-PR landing order.

**What's in here**

- **Levels 02–05:** bulletize 25 `:::exercise` blocks (paragraph prose → action list)
- **All levels:** add code-fence language hints (`bash`, `jsx`, `json`, `markdown`) where content is identifiably one of those languages; bare fences kept for diagrams, prompts, and pseudocode
- **3 lessons:** rename `:::resources{title="Links"}` → `"Go Deeper"` (canon)
- **Levels 02–05:** add inline-code formatting in prose where the audit flagged specific gaps (file paths, identifiers, API endpoints)
- **Level 01 (cherry-picked from #37–#42):** bulletize 6 `:::exercise` blocks + add inline-code formatting

The audit doc itself is updated as each box gets ticked (one commit per file), so the doc and code stay in lockstep through the PR.

**Workflow note**

This is the single-PR-for-the-whole-sweep packaging called out in the audit doc as a deliberate exception to the default one-file-per-branch curriculum workflow — the changes are uniform and audit-driven, so a single review pass against the audit doc is faster than 33 separate reviews.

**Closes**

- #14 (formatting audit)
- Supersedes #37, #38, #39, #40, #41, #42 (consolidated)

## Test plan

- [ ] `npm run build` succeeds (verified locally)
- [ ] Spot-check a level-01 lesson page renders bulleted exercise blocks (verified locally)
- [ ] Spot-check one lesson per level 02–05 to confirm bulletization renders
- [ ] Confirm code blocks with new language hints still render (no syntax-highlighting regressions)
- [ ] Confirm `:::resources` blocks render the new `Go Deeper` title